### PR TITLE
add operator ID to error response

### DIFF
--- a/pkgs/initiator/initiator.go
+++ b/pkgs/initiator/initiator.go
@@ -217,7 +217,7 @@ func (c *Initiator) SendToAll(method string, msg []byte, operatorsIDs []*wire.Op
 	for i := 0; i < len(operatorsIDs); i++ {
 		res := <-resc
 		if res.err != nil {
-			errarr = append(errarr, fmt.Errorf("operator ID: %d, %s", res.operatorID, res.err))
+			errarr = append(errarr, fmt.Errorf("operator ID: %d, %w", res.operatorID, res.err))
 			continue
 		}
 		final = append(final, res.result)

--- a/pkgs/initiator/initiator.go
+++ b/pkgs/initiator/initiator.go
@@ -217,7 +217,7 @@ func (c *Initiator) SendToAll(method string, msg []byte, operatorsIDs []*wire.Op
 	for i := 0; i < len(operatorsIDs); i++ {
 		res := <-resc
 		if res.err != nil {
-			errarr = append(errarr, res.err)
+			errarr = append(errarr, fmt.Errorf("operator ID: %d, %s", res.operatorID, res.err))
 			continue
 		}
 		final = append(final, res.result)


### PR DESCRIPTION
* add operator ID to request error

Returns:
```sh
initiator_1  | 2023-11-23T12:03:43.820354Z	FATAL	dkg-initiator	😥 Failed to initiate DKG ceremony: 	{"error": "operator ID: 3, Post \"http://operator3:3030/init\": net/http: request canceled (Client.Timeout exceeded while awaiting headers)\noperator ID: 4, Post \"http://operator4:3030/init\": net/http: request canceled (Client.Timeout exceeded while awaiting headers)\noperator ID: 1, Post \"http://operator1:3030/init\": net/http: request canceled (Client.Timeout exceeded while awaiting headers)\noperator ID: 2, Post \"http://operator2:3030/init\": net/http: request canceled (Client.Timeout exceeded while awaiting headers)"}
```