### PR TITLE
Audit fixes

### DIFF
--- a/cli/initiator/initiator.go
+++ b/cli/initiator/initiator.go
@@ -28,15 +28,15 @@ var StartDKG = &cobra.Command{
 		██║  ██║██╔═██╗ ██║   ██║    ██║██║╚██╗██║██║   ██║   ██║██╔══██║   ██║   ██║   ██║██╔══██╗
 		██████╔╝██║  ██╗╚██████╔╝    ██║██║ ╚████║██║   ██║   ██║██║  ██║   ██║   ╚██████╔╝██║  ██║
 		╚═════╝ ╚═╝  ╚═╝ ╚═════╝     ╚═╝╚═╝  ╚═══╝╚═╝   ╚═╝   ╚═╝╚═╝  ╚═╝   ╚═╝    ╚═════╝ ╚═╝  ╚═╝`)
-		if err := cli_utils.SetViperConfig(cmd); err != nil {
-			return err
-		}
-		if err := cli_utils.BindInitFlags(cmd); err != nil {
-			return err
-		}
 		logger, err := cli_utils.SetGlobalLogger(cmd, "dkg-initiator")
 		if err != nil {
 			return err
+		}
+		if err := cli_utils.SetViperConfig(cmd, logger); err != nil {
+			logger.Fatal("😥", zap.Error(err))
+		}
+		if err := cli_utils.BindInitFlags(cmd); err != nil {
+			logger.Fatal("😥", zap.Error(err))
 		}
 		logger.Info("🪛 Initiator`s", zap.String("Version", cmd.Version))
 		// Load operators TODO: add more sources.
@@ -44,7 +44,7 @@ var StartDKG = &cobra.Command{
 		if err != nil {
 			logger.Fatal("😥 Failed to load participants: ", zap.Error(err))
 		}
-		opMap, err := cli_utils.LoadOperators()
+		opMap, err := cli_utils.LoadOperators(logger)
 		if err != nil {
 			logger.Fatal("😥 Failed to load operators: ", zap.Error(err))
 		}

--- a/cli/initiator/reshare.go
+++ b/cli/initiator/reshare.go
@@ -33,18 +33,18 @@ var StartReshare = &cobra.Command{
 		░ ░  ░ ░ ░░ ░ ░ ░   ░      ░░   ░    ░   ░  ░  ░   ░  ░░ ░  ░   ▒     ░░   ░    ░   
 		░    ░  ░         ░       ░        ░  ░      ░   ░  ░  ░      ░  ░   ░        ░  ░
 		░`)
-		if err := cli_utils.SetViperConfig(cmd); err != nil {
+		logger, err := cli_utils.SetGlobalLogger(cmd, "dkg-initiator")
+		if err != nil {
+			return err
+		}
+		if err := cli_utils.SetViperConfig(cmd, logger); err != nil {
 			return err
 		}
 		if err := cli_utils.BindReshareFlags(cmd); err != nil {
 			return err
 		}
-		logger, err := cli_utils.SetGlobalLogger(cmd, "dkg-initiator")
-		if err != nil {
-			return err
-		}
 		logger.Info("🪛 Initiator`s", zap.String("Version", cmd.Version))
-		opMap, err := cli_utils.LoadOperators()
+		opMap, err := cli_utils.LoadOperators(logger)
 		if err != nil {
 			logger.Fatal("😥 Failed to load operators: ", zap.Error(err))
 		}

--- a/cli/operator/operator.go
+++ b/cli/operator/operator.go
@@ -26,14 +26,14 @@ var StartDKGOperator = &cobra.Command{
 		██║  ██║██╔═██╗ ██║   ██║    ██║   ██║██╔═══╝ ██╔══╝  ██╔══██╗██╔══██║   ██║   ██║   ██║██╔══██╗
 		██████╔╝██║  ██╗╚██████╔╝    ╚██████╔╝██║     ███████╗██║  ██║██║  ██║   ██║   ╚██████╔╝██║  ██║
 		╚═════╝ ╚═╝  ╚═╝ ╚═════╝      ╚═════╝ ╚═╝     ╚══════╝╚═╝  ╚═╝╚═╝  ╚═╝   ╚═╝    ╚═════╝ ╚═╝  ╚═╝`)
-		if err := cli_utils.SetViperConfig(cmd); err != nil {
+		logger, err := cli_utils.SetGlobalLogger(cmd, "dkg-operator")
+		if err != nil {
+			return err
+		}
+		if err := cli_utils.SetViperConfig(cmd, logger); err != nil {
 			return err
 		}
 		if err := cli_utils.BindOperatorFlags(cmd); err != nil {
-			return err
-		}
-		logger, err := cli_utils.SetGlobalLogger(cmd, "dkg-operator")
-		if err != nil {
 			return err
 		}
 		logger.Info("🪛 Operator`s", zap.String("Version", cmd.Version))

--- a/cli/operator/operator.go
+++ b/cli/operator/operator.go
@@ -47,11 +47,13 @@ var StartDKGOperator = &cobra.Command{
 		if err != nil {
 			logger.Fatal("😥 Failed to load DB: ", zap.Error(err))
 		}
-		srv := operator.New(privateKey, logger, DBOptions, []byte(cmd.Version), cli_utils.OperatorID)
+		srv, err := operator.New(privateKey, logger, DBOptions, []byte(cmd.Version), cli_utils.OperatorID)
+		if err != nil {
+			logger.Fatal("😥 Failed to create new operator instance: ", zap.Error(err))
+		}
 		logger.Info("🚀 Starting DKG operator", zap.Uint64("at port", cli_utils.Port))
 		if err := srv.Start(uint16(cli_utils.Port)); err != nil {
 			log.Fatalf("Error in operator %v", err)
-			return err
 		}
 		return nil
 	},

--- a/cli/utils/utils.go
+++ b/cli/utils/utils.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -464,6 +465,16 @@ func StingSliceToUintArray(flagdata []string) ([]uint64, error) {
 		}
 		partsarr = append(partsarr, opid)
 	}
+	// sort array
+	sort.SliceStable(partsarr, func(i, j int) bool {
+		return partsarr[i] < partsarr[j]
+	})
+	sorted := sort.SliceIsSorted(partsarr, func(p, q int) bool {
+		return partsarr[p] < partsarr[q]
+	})
+	if !sorted {
+		return nil, fmt.Errorf("slice isnt sorted")
+	}
 	return partsarr, nil
 }
 
@@ -598,7 +609,11 @@ func WriteInitResults(depositDataArr []*initiator.DepositDataJson, keySharesArr 
 		}
 		keysharesFinalPath := fmt.Sprintf("%s/keyshares.json", dir)
 		logger.Info("💾 Writing keyshares payload to file", zap.String("path", keysharesFinalPath))
-		err = utils.WriteJSON(keysharesFinalPath, initiator.GenerateAggregatesKeyshares(keySharesArr))
+		aggrKeySharesArr, err := initiator.GenerateAggregatesKeyshares(keySharesArr)
+		if err != nil {
+			logger.Fatal("error: ", zap.Error(err))
+		}
+		err = utils.WriteJSON(keysharesFinalPath, aggrKeySharesArr)
 		if err != nil {
 			logger.Fatal("Failed writing instance IDs to file: ", zap.Error(err), zap.String("path", keysharesFinalPath), zap.Any("keyshares", keySharesArr))
 		}

--- a/cli/utils/utils.go
+++ b/cli/utils/utils.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -265,6 +266,9 @@ func BindBaseFlags(cmd *cobra.Command) error {
 		return err
 	}
 	OutputPath = viper.GetString("outputPath")
+	if strings.Contains(OutputPath, "../") {
+		return fmt.Errorf("😥 outputPath should not contain traversal")
+	}
 	if stat, err := os.Stat(OutputPath); err != nil || !stat.IsDir() {
 		return fmt.Errorf("😥 Error to to open path to store results %s", err.Error())
 	}
@@ -272,6 +276,9 @@ func BindBaseFlags(cmd *cobra.Command) error {
 	LogFormat = viper.GetString("logFormat")
 	LogLevelFormat = viper.GetString("logLevelFormat")
 	LogFilePath = viper.GetString("logFilePath")
+	if strings.Contains(LogFilePath, "../") {
+		return fmt.Errorf("😥 logFilePath should not contain traversal")
+	}
 	if LogFilePath == "" {
 		fmt.Println("⚠️ debug log path was not provided, using default: ./initiator_debug.log")
 	}
@@ -303,6 +310,9 @@ func BindInitiatorBaseFlags(cmd *cobra.Command) error {
 		return err
 	}
 	ConfigPath = viper.GetString("configPath")
+	if strings.Contains(ConfigPath, "../") {
+		return fmt.Errorf("😥 configPath should not contain traversal")
+	}
 	if stat, err := os.Stat(ConfigPath); !stat.IsDir() || os.IsNotExist(err) {
 		return fmt.Errorf("😥 configPath isnt a folder path or not exist: %s", err)
 	}
@@ -314,6 +324,9 @@ func BindInitiatorBaseFlags(cmd *cobra.Command) error {
 	OperatorsInfoPath = viper.GetString("operatorsInfoPath")
 	if OperatorsInfo == "" && OperatorsInfoPath == "" {
 		return fmt.Errorf("😥 Operators string or path have not provided")
+	}
+	if strings.Contains(OperatorsInfoPath, "../") {
+		return fmt.Errorf("😥 operatorsInfoPath should not contain traversal")
 	}
 	if OperatorsInfo != "" && OperatorsInfoPath != "" {
 		return fmt.Errorf("😥 Please provide either operator info string or path, not both")
@@ -436,6 +449,9 @@ func BindOperatorFlags(cmd *cobra.Command) error {
 		return fmt.Errorf("😥 Wrong operator ID provided")
 	}
 	DBPath = viper.GetString("DBPath")
+	if strings.Contains(DBPath, "../") {
+		return fmt.Errorf("😥 DBPath should not contain traversal")
+	}
 	DBReporting = viper.GetBool("DBReporting")
 	DBGCInterval = viper.GetString("DBGCInterval")
 	return nil

--- a/cli/utils/utils.go
+++ b/cli/utils/utils.go
@@ -93,7 +93,7 @@ func SetViperConfig(cmd *cobra.Command) error {
 // SetGlobalLogger creates a logger
 func SetGlobalLogger(cmd *cobra.Command, name string) (*zap.Logger, error) {
 	// If the log file doesn't exist, create it
-	_, err := os.OpenFile(LogFilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	_, err := os.OpenFile(LogFilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
 	if err != nil {
 		return nil, err
 	}
@@ -489,7 +489,7 @@ func LoadInitiatorRSAPrivKey(generate bool) (*rsa.PrivateKey, error) {
 				if err != nil {
 					return nil, err
 				}
-				err = os.WriteFile(privKeyPassPath, []byte(password), 0o644)
+				err = os.WriteFile(privKeyPassPath, []byte(password), 0o600)
 				if err != nil {
 					return nil, err
 				}
@@ -506,7 +506,7 @@ func LoadInitiatorRSAPrivKey(generate bool) (*rsa.PrivateKey, error) {
 			if err != nil {
 				return nil, fmt.Errorf("😥 Error converting pem to priv key: %s", err)
 			}
-			err = os.WriteFile(privKeyPath, encryptedRSAJSON, 0o644)
+			err = os.WriteFile(privKeyPath, encryptedRSAJSON, 0o600)
 			if err != nil {
 				return nil, err
 			}

--- a/integration_test/integration_test.go
+++ b/integration_test/integration_test.go
@@ -615,6 +615,7 @@ func testSharesData(ops map[uint64]initiator.Operator, operatorCount int, keys [
 		for id, op := range ops {
 			if bytes.Equal(priv.PublicKey.N.Bytes(), op.PubKey.N.Bytes()) {
 				operatorID = id
+				break
 			}
 		}
 		sig := secret.SignByte(msg)

--- a/integration_test/integration_test.go
+++ b/integration_test/integration_test.go
@@ -27,9 +27,8 @@ import (
 const encryptedKeyLength = 256
 
 func TestHappyFlows(t *testing.T) {
-	if err := logging.SetGlobalLogger("info", "capital", "console", nil); err != nil {
-		panic(err)
-	}
+	err := logging.SetGlobalLogger("info", "capital", "console", nil)
+	require.NoError(t, err)
 	logger := zap.L().Named("integration-tests")
 	ops := make(map[uint64]initiator.Operator)
 	srv1 := test_utils.CreateTestOperator(t, 1, "v1.0.2")
@@ -147,9 +146,8 @@ func TestHappyFlows(t *testing.T) {
 }
 
 func TestThreshold(t *testing.T) {
-	if err := logging.SetGlobalLogger("info", "capital", "console", nil); err != nil {
-		panic(err)
-	}
+	err := logging.SetGlobalLogger("info", "capital", "console", nil)
+	require.NoError(t, err)
 	logger := zap.L().Named("integration-tests")
 	ops := make(map[uint64]initiator.Operator)
 	srv1 := test_utils.CreateTestOperator(t, 1, "v1.0.2")
@@ -281,9 +279,8 @@ func TestThreshold(t *testing.T) {
 }
 
 func TestUnhappyFlows(t *testing.T) {
-	if err := logging.SetGlobalLogger("info", "capital", "console", nil); err != nil {
-		panic(err)
-	}
+	err := logging.SetGlobalLogger("info", "capital", "console", nil)
+	require.NoError(t, err)
 	logger := zap.L().Named("integration-tests")
 	ops := make(map[uint64]initiator.Operator)
 	srv1 := test_utils.CreateTestOperator(t, 1, "v1.0.2")
@@ -380,9 +377,8 @@ func TestUnhappyFlows(t *testing.T) {
 }
 
 func TestReshareHappyFlow(t *testing.T) {
-	if err := logging.SetGlobalLogger("debug", "capital", "console", nil); err != nil {
-		panic(err)
-	}
+	err := logging.SetGlobalLogger("debug", "capital", "console", nil)
+	require.NoError(t, err)
 	logger := zap.L().Named("integration-tests")
 	ops := make(map[uint64]initiator.Operator)
 	srv1 := test_utils.CreateTestOperator(t, 1, "v1.0.2")
@@ -522,9 +518,8 @@ func TestReshareHappyFlow(t *testing.T) {
 }
 
 func TestWrongInitiatorVersion(t *testing.T) {
-	if err := logging.SetGlobalLogger("info", "capital", "console", nil); err != nil {
-		panic(err)
-	}
+	err := logging.SetGlobalLogger("info", "capital", "console", nil)
+	require.NoError(t, err)
 	logger := zap.L().Named("integration-tests")
 	ops := make(map[uint64]initiator.Operator)
 	srv1 := test_utils.CreateTestOperator(t, 1, "v1.0.2")
@@ -553,9 +548,8 @@ func TestWrongInitiatorVersion(t *testing.T) {
 }
 
 func TestWrongOperatorVersion(t *testing.T) {
-	if err := logging.SetGlobalLogger("info", "capital", "console", nil); err != nil {
-		panic(err)
-	}
+	err := logging.SetGlobalLogger("info", "capital", "console", nil)
+	require.NoError(t, err)
 	logger := zap.L().Named("integration-tests")
 	ops := make(map[uint64]initiator.Operator)
 	srv1 := test_utils.CreateTestOperator(t, 1, "v1.0.0")

--- a/integration_test/integration_test.go
+++ b/integration_test/integration_test.go
@@ -315,28 +315,6 @@ func TestUnhappyFlows(t *testing.T) {
 	require.NoError(t, err)
 	err = initiator.VerifyDepositData(depositData, withdraw.Bytes(), owner, 0)
 	require.NoError(t, err)
-	t.Run("test wrong operators shares order at SSV payload", func(t *testing.T) {
-		withdraw := newEthAddress(t)
-		owner := newEthAddress(t)
-		id := crypto.NewID()
-		_, ks, err = clnt.StartDKG(id, withdraw.Bytes(), []uint64{13, 3, 2, 4, 5, 6, 7, 8, 9, 10, 11, 12, 1}, "mainnet", owner, 0)
-		require.NoError(t, err)
-		sharesDataSigned, err := hex.DecodeString(ks.Shares[0].Payload.SharesData[2:])
-		require.NoError(t, err)
-		pubkeyraw, err := hex.DecodeString(ks.Shares[0].Payload.PublicKey[2:])
-		require.NoError(t, err)
-		signatureOffset := phase0.SignatureLength
-		pubKeysOffset := phase0.PublicKeyLength*13 + signatureOffset
-		_ = utils.SplitBytes(sharesDataSigned[signatureOffset:pubKeysOffset], phase0.PublicKeyLength)
-		encryptedKeys := utils.SplitBytes(sharesDataSigned[pubKeysOffset:], len(sharesDataSigned[pubKeysOffset:])/13)
-		wrongOrderSharesData := make([]byte, 0)
-		wrongOrderSharesData = append(wrongOrderSharesData, sharesDataSigned[:pubKeysOffset]...)
-		for i := len(encryptedKeys) - 1; i >= 0; i-- {
-			wrongOrderSharesData = append(wrongOrderSharesData, encryptedKeys[i]...)
-		}
-		err = testSharesData(ops, 13, []*rsa.PrivateKey{srv13.PrivKey, srv12.PrivKey, srv11.PrivKey, srv10.PrivKey, srv9.PrivKey, srv8.PrivKey, srv7.PrivKey, srv6.PrivKey, srv5.PrivKey, srv4.PrivKey, srv3.PrivKey, srv2.PrivKey, srv1.PrivKey}, wrongOrderSharesData, pubkeyraw, owner, 0)
-		require.ErrorContains(t, err, "shares order is incorrect")
-	})
 	t.Run("test same ID", func(t *testing.T) {
 		_, _, err = clnt.StartDKG(id, withdraw.Bytes(), []uint64{1, 2, 3, 4}, "mainnet", owner, 0)
 		require.ErrorContains(t, err, "got init msg for existing instance")

--- a/integration_test/integration_test.go
+++ b/integration_test/integration_test.go
@@ -117,19 +117,6 @@ func TestHappyFlows(t *testing.T) {
 		err = initiator.VerifyDepositData(depositData, withdraw.Bytes(), owner, 0)
 		require.NoError(t, err)
 	})
-	t.Run("test 13 operators - random operators order", func(t *testing.T) {
-		id := crypto.NewID()
-		depositData, ks, err := clnt.StartDKG(id, withdraw.Bytes(), []uint64{13, 3, 2, 4, 5, 6, 7, 8, 9, 10, 11, 12, 1}, "mainnet", owner, 0)
-		require.NoError(t, err)
-		sharesDataSigned, err := hex.DecodeString(ks.Shares[0].Payload.SharesData[2:])
-		require.NoError(t, err)
-		pubkeyraw, err := hex.DecodeString(ks.Shares[0].Payload.PublicKey[2:])
-		require.NoError(t, err)
-		err = testSharesData(ops, 13, []*rsa.PrivateKey{srv1.PrivKey, srv2.PrivKey, srv3.PrivKey, srv4.PrivKey, srv5.PrivKey, srv6.PrivKey, srv7.PrivKey, srv8.PrivKey, srv9.PrivKey, srv10.PrivKey, srv11.PrivKey, srv12.PrivKey, srv13.PrivKey}, sharesDataSigned, pubkeyraw, owner, 0)
-		require.NoError(t, err)
-		err = initiator.VerifyDepositData(depositData, withdraw.Bytes(), owner, 0)
-		require.NoError(t, err)
-	})
 	srv1.HttpSrv.Close()
 	srv2.HttpSrv.Close()
 	srv3.HttpSrv.Close()
@@ -586,7 +573,7 @@ func testSharesData(ops map[uint64]initiator.Operator, operatorCount int, keys [
 	}
 	signature := sharesData[:signatureOffset]
 	msg := []byte("Hello")
-	err := crypto.VerifyOwnerNoceSignature(signature, owner, validatorPublicKey, nonce)
+	err := crypto.VerifyOwnerNonceSignature(signature, owner, validatorPublicKey, nonce)
 	if err != nil {
 		return err
 	}

--- a/pkgs/crypto/crypto.go
+++ b/pkgs/crypto/crypto.go
@@ -46,7 +46,7 @@ func init() {
 
 // GenerateKeys creates a random RSA key pair
 func GenerateKeys() (*rsa.PrivateKey, *rsa.PublicKey, error) {
-	pv, err := rsa.GenerateKey(rand.Reader, 1024)
+	pv, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkgs/crypto/crypto.go
+++ b/pkgs/crypto/crypto.go
@@ -127,6 +127,9 @@ func ParseRSAPubkey(pk []byte) (*rsa.PublicKey, error) {
 		return nil, err
 	}
 	pemblock, _ := pem.Decode(operatorKeyByte)
+	if pemblock == nil {
+		return nil, errors.New("decode PEM block")
+	}
 	pbkey, err := x509.ParsePKIXPublicKey(pemblock.Bytes)
 	if err != nil {
 		return nil, err
@@ -145,6 +148,9 @@ func EncodePublicKey(pk *rsa.PublicKey) ([]byte, error) {
 			Bytes: pkBytes,
 		},
 	)
+	if pemByte == nil {
+		return nil, fmt.Errorf("failed to encode pub key to pem")
+	}
 
 	return []byte(base64.StdEncoding.EncodeToString(pemByte)), nil
 }
@@ -202,17 +208,6 @@ func ReadEncryptedPrivateKey(keyData []byte, password string) (*rsa.PrivateKey, 
 	}
 
 	return rsaKey, nil
-}
-
-// ExtractPrivateKey gets private key and returns base64 encoded private key
-func ExtractPrivateKey(sk *rsa.PrivateKey) string {
-	pemByte := pem.EncodeToMemory(
-		&pem.Block{
-			Type:  "RSA PRIVATE KEY",
-			Bytes: x509.MarshalPKCS1PrivateKey(sk),
-		},
-	)
-	return base64.StdEncoding.EncodeToString(pemByte)
 }
 
 // ConvertPemToPrivateKey return rsa private key from secret key

--- a/pkgs/crypto/crypto.go
+++ b/pkgs/crypto/crypto.go
@@ -155,8 +155,8 @@ func EncodePublicKey(pk *rsa.PublicKey) ([]byte, error) {
 	return []byte(base64.StdEncoding.EncodeToString(pemByte)), nil
 }
 
-// VerifyOwnerNoceSignature check that owner + nonce correctly signed
-func VerifyOwnerNoceSignature(sig []byte, owner common.Address, pubKey []byte, nonce uint16) error {
+// VerifyOwnerNonceSignature check that owner + nonce correctly signed
+func VerifyOwnerNonceSignature(sig []byte, owner common.Address, pubKey []byte, nonce uint16) error {
 	data := fmt.Sprintf("%s:%d", owner.String(), nonce)
 	hash := eth_crypto.Keccak256([]byte(data))
 
@@ -253,6 +253,9 @@ func RecoverValidatorPublicKey(IDs []uint64, sharePks []*bls.PublicKey) (*bls.Pu
 
 // RecoverMasterSig recovers a BLS master signature from T-threshold partial signatures
 func RecoverMasterSig(IDs []uint64, sigDepositShares []*bls.Sign) (*bls.Sign, error) {
+	if len(IDs) != len(sigDepositShares) {
+		return nil, fmt.Errorf("inconsistent IDs len")
+	}
 	reconstructedDepositMasterSig := bls.Sign{}
 	idVec := make([]bls.ID, 0)
 	sigVec := make([]bls.Sign, 0)
@@ -462,6 +465,9 @@ func SignDepositData(validationKey *bls.SecretKey, withdrawalPubKey []byte, vali
 
 // VerifyPartialSigs verifies provided partial BLS signatures
 func VerifyPartialSigs(sigShares []*bls.Sign, sharePks []*bls.PublicKey, data []byte) error {
+	if len(sigShares) != len(sharePks) {
+		return fmt.Errorf("inconsistent slice lengths")
+	}
 	res := make([]bool, len(sigShares))
 	for i := 0; i < len(sigShares); i++ {
 		if sigShares[i].VerifyByte(sharePks[i], data) {
@@ -528,6 +534,9 @@ func GenerateSecurePassword() (string, error) {
 // ReconstructSignatures receives a map of user indexes and serialized bls.Sign.
 // It then reconstructs the original threshold signature using lagrange interpolation
 func ReconstructSignatures(IDs []uint64, signatures [][]byte) (*bls.Sign, error) {
+	if len(IDs) != len(signatures) {
+		return nil, fmt.Errorf("inconsistent IDs len")
+	}
 	reconstructedSig := bls.Sign{}
 	idVec := make([]bls.ID, 0)
 	sigVec := make([]bls.Sign, 0)

--- a/pkgs/crypto/crypto_test.go
+++ b/pkgs/crypto/crypto_test.go
@@ -180,7 +180,7 @@ func NodesFromTest(tns []*TestNode) []dkg.Node {
 }
 
 // inits the dkg structure
-func SetupNodes(nodes []*TestNode, c *dkg.Config) {
+func SetupNodes(nodes []*TestNode, c *dkg.Config) error {
 	nonce := dkg.GetNonce()
 	for _, n := range nodes {
 		c2 := *c
@@ -188,13 +188,14 @@ func SetupNodes(nodes []*TestNode, c *dkg.Config) {
 		c2.Nonce = nonce
 		dkgProto, err := dkg.NewDistKeyHandler(&c2)
 		if err != nil {
-			panic(err)
+			return err
 		}
 		n.dkg = dkgProto
 	}
+	return nil
 }
 
-func SetupReshareNodes(nodes []*TestNode, c *dkg.Config, coeffs []kyber.Point) {
+func SetupReshareNodes(nodes []*TestNode, c *dkg.Config, coeffs []kyber.Point) error {
 	nonce := dkg.GetNonce()
 	for _, n := range nodes {
 		c2 := *c
@@ -207,10 +208,11 @@ func SetupReshareNodes(nodes []*TestNode, c *dkg.Config, coeffs []kyber.Point) {
 		}
 		dkgProto, err := dkg.NewDistKeyHandler(&c2)
 		if err != nil {
-			panic(err)
+			return err
 		}
 		n.dkg = dkgProto
 	}
+	return nil
 }
 
 func IsDealerIncluded(bundles []*dkg.ResponseBundle, dealer uint32) bool {
@@ -308,13 +310,13 @@ func (n *TestNetwork) SetNoop(index uint32) {
 	n.noops = append(n.noops, index)
 }
 
-func (n *TestNetwork) BoardFor(index uint32) *TestBoard {
+func (n *TestNetwork) BoardFor(index uint32) (*TestBoard, error) {
 	for _, b := range n.boards {
 		if b.index == index {
-			return b
+			return b, nil
 		}
 	}
-	panic("no such indexes")
+	return nil, errors.New("no such indexes")
 }
 
 func (n *TestNetwork) isNoop(i uint32) bool {

--- a/pkgs/dkg/drand.go
+++ b/pkgs/dkg/drand.go
@@ -389,6 +389,10 @@ func (o *LocalOwner) PostDKG(res *kyber_dkg.OptionResult) error {
 	o.Logger.Debug("Domain", zap.String("bytes", fmt.Sprintf("%x", ssvspec_types.DomainDeposit[:])))
 	// Sign root
 	depositRootSig, signRoot, err := crypto.SignDepositData(secretKeyBLS, o.data.init.WithdrawalCredentials, validatorPubKey, utils.GetNetworkByFork(o.data.init.Fork), MaxEffectiveBalanceInGwei)
+	if err != nil {
+		o.broadcastError(err)
+		return err
+	}
 	o.Logger.Debug("Root", zap.String("", fmt.Sprintf("%x", signRoot)))
 	// Validate partial signature
 	val := depositRootSig.VerifyByte(secretKeyBLS.GetPublicKey(), signRoot)

--- a/pkgs/dkg/drand.go
+++ b/pkgs/dkg/drand.go
@@ -203,7 +203,9 @@ func (o *LocalOwner) StartDKG() error {
 	// Wait when the protocol exchanges finish and process the result
 	go func(p *kyber_dkg.Protocol, postF func(res *kyber_dkg.OptionResult) error) {
 		res := <-p.WaitEnd()
-		postF(&res)
+		if err := postF(&res); err != nil {
+			o.Logger.Error("Error in PostDKG function", zap.Error(err))
+		}
 	}(p, o.PostDKG)
 	close(o.startedDKG)
 	return nil
@@ -239,7 +241,9 @@ func (o *LocalOwner) StartReshareDKGOldNodes() error {
 
 	go func(p *kyber_dkg.Protocol, postF func(res *kyber_dkg.OptionResult) error) {
 		res := <-p.WaitEnd()
-		postF(&res)
+		if err := postF(&res); err != nil {
+			o.Logger.Error("Error in postReshare function", zap.Error(err))
+		}
 	}(p, o.postReshare)
 	close(o.startedDKG)
 	return nil
@@ -305,7 +309,9 @@ func (o *LocalOwner) StartReshareDKGNewNodes() error {
 	}
 	go func(p *kyber_dkg.Protocol, postF func(res *kyber_dkg.OptionResult) error) {
 		res := <-p.WaitEnd()
-		postF(&res)
+		if err := postF(&res); err != nil {
+			o.Logger.Error("Error in postReshare function", zap.Error(err))
+		}
 	}(p, o.postReshare)
 	return nil
 }
@@ -347,7 +353,6 @@ func (o *LocalOwner) Broadcast(ts *wire.Transport) error {
 // and creates the Result structure to send back to initiator
 func (o *LocalOwner) PostDKG(res *kyber_dkg.OptionResult) error {
 	if res.Error != nil {
-		o.Logger.Error("DKG ceremony returned error: ", zap.Error(res.Error))
 		o.broadcastError(res.Error)
 		return res.Error
 	}
@@ -430,7 +435,6 @@ func (o *LocalOwner) PostDKG(res *kyber_dkg.OptionResult) error {
 
 func (o *LocalOwner) postReshare(res *kyber_dkg.OptionResult) error {
 	if res.Error != nil {
-		o.Logger.Error("DKG ceremony returned error: ", zap.Error(res.Error))
 		o.broadcastError(res.Error)
 		return res.Error
 	}

--- a/pkgs/dkg/drand_test.go
+++ b/pkgs/dkg/drand_test.go
@@ -14,6 +14,7 @@ import (
 	kyber_dkg "github.com/drand/kyber/share/dkg"
 	"github.com/ethereum/go-ethereum/common"
 	herumi_bls "github.com/herumi/bls-eth-go-binary/bls"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
@@ -42,7 +43,7 @@ func (tv *testVerify) Add(id uint64, pk *rsa.PublicKey) {
 func (tv *testVerify) Verify(id uint64, msg, sig []byte) error {
 	op, ok := tv.ops[id]
 	if !ok {
-		panic("test shouldn't do this")
+		return errors.New("test shouldn't do this")
 	}
 	return crypto.VerifyRSA(op, msg, sig)
 }

--- a/pkgs/initiator/initiator.go
+++ b/pkgs/initiator/initiator.go
@@ -926,7 +926,7 @@ func LoadOperatorsJson(operatorsMetaData []byte) (Operators, error) {
 		}
 		pemBlock, _ := pem.Decode(operatorKeyByte)
 		if pemBlock == nil {
-			return nil, fmt.Errorf("wrong pub key string")
+			return nil, errors.New("decode PEM block")
 		}
 		pbKey, err := x509.ParsePKIXPublicKey(pemBlock.Bytes)
 		if err != nil {

--- a/pkgs/initiator/initiator_test.go
+++ b/pkgs/initiator/initiator_test.go
@@ -42,9 +42,8 @@ var jsonStr = []byte(`[
 const examplePath = "../../examples/"
 
 func TestStartDKG(t *testing.T) {
-	if err := logging.SetGlobalLogger("debug", "capital", "console", nil); err != nil {
-		panic(err)
-	}
+	err := logging.SetGlobalLogger("debug", "capital", "console", nil)
+	require.NoError(t, err)
 	logger := zap.L().Named("operator-tests")
 	ops := make(map[uint64]initiator.Operator)
 	version := "v1.0.2"

--- a/pkgs/initiator/initiator_test.go
+++ b/pkgs/initiator/initiator_test.go
@@ -114,7 +114,7 @@ func TestLoadOperators(t *testing.T) {
         "ip": "http://localhost:3030"
       }
     ]`))
-		require.ErrorContains(t, err, "wrong pub key string")
+		require.ErrorContains(t, err, "decode PEM block")
 	})
 	t.Run("test wrong operator URL", func(t *testing.T) {
 		_, err := initiator.LoadOperatorsJson([]byte(`[

--- a/pkgs/initiator/initiator_test.go
+++ b/pkgs/initiator/initiator_test.go
@@ -67,7 +67,7 @@ func TestStartDKG(t *testing.T) {
 		id := crypto.NewID()
 		depositData, keyshares, err := intr.StartDKG(id, withdraw.Bytes(), []uint64{1, 2, 3, 4}, "mainnet", owner, 0)
 		require.NoError(t, err)
-		err = initiator.VerifySharesData(ops, []*rsa.PrivateKey{srv1.PrivKey, srv2.PrivKey, srv3.PrivKey, srv4.PrivKey}, keyshares, owner, 0)
+		err = test_utils.VerifySharesData([]uint64{1, 2, 3, 4}, []*rsa.PrivateKey{srv1.PrivKey, srv2.PrivKey, srv3.PrivKey, srv4.PrivKey}, keyshares, owner, 0)
 		require.NoError(t, err)
 		err = initiator.VerifyDepositData(depositData, withdraw.Bytes(), owner, 0)
 		require.NoError(t, err)

--- a/pkgs/operator/operator.go
+++ b/pkgs/operator/operator.go
@@ -248,7 +248,7 @@ func New(key *rsa.PrivateKey, logger *zap.Logger, dbOptions basedb.Options, ver 
 
 // Start runs a http server to listen for incoming messages at specified port
 func (s *Server) Start(port uint16) error {
-	srv := &http.Server{Addr: fmt.Sprintf(":%v", port), Handler: s.Router}
+	srv := &http.Server{Addr: fmt.Sprintf(":%v", port), Handler: s.Router, ReadHeaderTimeout: 100 * time.Millisecond}
 	s.HttpServer = srv
 	err := s.HttpServer.ListenAndServe()
 	if err != nil {

--- a/pkgs/operator/operator.go
+++ b/pkgs/operator/operator.go
@@ -223,17 +223,17 @@ func RegisterRoutes(s *Server) {
 }
 
 // New creates Server structure using operator's RSA private key
-func New(key *rsa.PrivateKey, logger *zap.Logger, dbOptions basedb.Options, ver []byte, id uint64) *Server {
+func New(key *rsa.PrivateKey, logger *zap.Logger, dbOptions basedb.Options, ver []byte, id uint64) (*Server, error) {
 	r := chi.NewRouter()
 	db, err := setupDB(logger, dbOptions)
 	// todo: handle error
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 	operatorPubKey := key.Public().(*rsa.PublicKey)
 	pkBytes, err := crypto.EncodePublicKey(operatorPubKey)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 	swtch := NewSwitch(key, logger, db, ver, pkBytes, id)
 	s := &Server{
@@ -243,7 +243,7 @@ func New(key *rsa.PrivateKey, logger *zap.Logger, dbOptions basedb.Options, ver 
 		DB:     db,
 	}
 	RegisterRoutes(s)
-	return s
+	return s, nil
 }
 
 // Start runs a http server to listen for incoming messages at specified port

--- a/pkgs/operator/operator_test.go
+++ b/pkgs/operator/operator_test.go
@@ -36,9 +36,7 @@ func TestRateLimit(t *testing.T) {
 	require.NoError(t, err)
 	pubKey := priv.Public().(*rsa.PublicKey)
 	initPubBytes, err := crypto.EncodePublicKey(pubKey)
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
 	t.Run("test /init rate limit", func(t *testing.T) {
 		ops := make(map[uint64]initiator.Operator)
 		ops[1] = initiator.Operator{Addr: srv.HttpSrv.URL, ID: 1, PubKey: &srv.PrivKey.PublicKey}
@@ -154,9 +152,8 @@ func TestRateLimit(t *testing.T) {
 }
 
 func TestWrongInitiatorSignature(t *testing.T) {
-	if err := logging.SetGlobalLogger("info", "capital", "console", nil); err != nil {
-		panic(err)
-	}
+	err := logging.SetGlobalLogger("info", "capital", "console", nil)
+	require.NoError(t, err)
 	logger := zap.L().Named("operator-tests")
 	ops := make(map[uint64]initiator.Operator)
 	version := "v1.0.2"

--- a/pkgs/operator/state_test.go
+++ b/pkgs/operator/state_test.go
@@ -53,9 +53,8 @@ func generateOperatorsData(t *testing.T, numOps int) (*rsa.PrivateKey, []*wire.O
 }
 
 func TestCreateInstance(t *testing.T) {
-	if err := logging.SetGlobalLogger("info", "capital", "console", nil); err != nil {
-		panic(err)
-	}
+	err := logging.SetGlobalLogger("info", "capital", "console", nil)
+	require.NoError(t, err)
 	logger := zap.L().Named("state-tests")
 	db, err := kv.NewInMemory(logging.TestLogger(t), basedb.Options{
 		Reporting: true,
@@ -67,9 +66,7 @@ func TestCreateInstance(t *testing.T) {
 		privateKey, ops := generateOperatorsData(t, numOps)
 		operatorPubKey := privateKey.Public().(*rsa.PublicKey)
 		pkBytes, err := crypto.EncodePublicKey(operatorPubKey)
-		if err != nil {
-			panic(err)
-		}
+		require.NoError(t, err)
 		s := NewSwitch(privateKey, logger, db, []byte("v1.0.2"), pkBytes, 1)
 		var reqID [24]byte
 		copy(reqID[:], "testRequestID1234567890") // Just a sample value
@@ -114,9 +111,8 @@ func TestCreateInstance(t *testing.T) {
 }
 
 func TestInitInstance(t *testing.T) {
-	if err := logging.SetGlobalLogger("info", "capital", "console", nil); err != nil {
-		panic(err)
-	}
+	err := logging.SetGlobalLogger("info", "capital", "console", nil)
+	require.NoError(t, err)
 	logger := zap.L().Named("state-tests")
 	privateKey, ops := generateOperatorsData(t, 4)
 	db, err := kv.NewInMemory(logging.TestLogger(t), basedb.Options{
@@ -127,9 +123,7 @@ func TestInitInstance(t *testing.T) {
 	require.NoError(t, err)
 	operatorPubKey := privateKey.Public().(*rsa.PublicKey)
 	pkBytes, err := crypto.EncodePublicKey(operatorPubKey)
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
 	swtch := NewSwitch(privateKey, logger, db, []byte("v1.0.2"), pkBytes, 1)
 	var reqID [24]byte
 	copy(reqID[:], "testRequestID1234567890") // Just a sample value
@@ -201,9 +195,8 @@ func TestInitInstance(t *testing.T) {
 
 func TestSwitch_cleanInstances(t *testing.T) {
 	privateKey, ops := generateOperatorsData(t, 4)
-	if err := logging.SetGlobalLogger("info", "capital", "console", nil); err != nil {
-		panic(err)
-	}
+	err := logging.SetGlobalLogger("info", "capital", "console", nil)
+	require.NoError(t, err)
 	logger := zap.L().Named("state-tests")
 	db, err := kv.NewInMemory(logging.TestLogger(t), basedb.Options{
 		Reporting: true,
@@ -213,9 +206,7 @@ func TestSwitch_cleanInstances(t *testing.T) {
 	require.NoError(t, err)
 	operatorPubKey := privateKey.Public().(*rsa.PublicKey)
 	pkBytes, err := crypto.EncodePublicKey(operatorPubKey)
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
 	swtch := NewSwitch(privateKey, logger, db, []byte("v1.0.2"), pkBytes, 1)
 	var reqID [24]byte
 	copy(reqID[:], "testRequestID1234567890") // Just a sample value
@@ -263,9 +254,8 @@ func TestSwitch_cleanInstances(t *testing.T) {
 
 func TestEncryptDercyptDB(t *testing.T) {
 	privateKey, _ := generateOperatorsData(t, 4)
-	if err := logging.SetGlobalLogger("info", "capital", "console", nil); err != nil {
-		panic(err)
-	}
+	err := logging.SetGlobalLogger("info", "capital", "console", nil)
+	require.NoError(t, err)
 	logger := zap.L().Named("state-tests")
 	db, err := kv.NewInMemory(logging.TestLogger(t), basedb.Options{
 		Reporting: true,
@@ -275,9 +265,7 @@ func TestEncryptDercyptDB(t *testing.T) {
 	require.NoError(t, err)
 	operatorPubKey := privateKey.Public().(*rsa.PublicKey)
 	pkBytes, err := crypto.EncodePublicKey(operatorPubKey)
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
 	swtch := NewSwitch(privateKey, logger, db, []byte("v1.0.2"), pkBytes, 1)
 	id := crypto.NewID()
 
@@ -296,9 +284,8 @@ func TestEncryptDercyptDB(t *testing.T) {
 }
 
 func TestEncryptDercyptDBInstance(t *testing.T) {
-	if err := logging.SetGlobalLogger("info", "capital", "console", nil); err != nil {
-		panic(err)
-	}
+	err := logging.SetGlobalLogger("info", "capital", "console", nil)
+	require.NoError(t, err)
 	logger := zap.L().Named("state-tests")
 	privateKey, ops := generateOperatorsData(t, 4)
 	db, err := kv.NewInMemory(logging.TestLogger(t), basedb.Options{
@@ -309,9 +296,7 @@ func TestEncryptDercyptDBInstance(t *testing.T) {
 	require.NoError(t, err)
 	operatorPubKey := privateKey.Public().(*rsa.PublicKey)
 	pkBytes, err := crypto.EncodePublicKey(operatorPubKey)
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
 	swtch := NewSwitch(privateKey, logger, db, []byte("v1.0.2"), pkBytes, 1)
 	var reqID [24]byte
 	copy(reqID[:], "testRequestID1234567890") // Just a sample value

--- a/pkgs/utils/test_utils/test_utls.go
+++ b/pkgs/utils/test_utils/test_utls.go
@@ -128,7 +128,7 @@ func VerifySharesData(IDs []uint64, keys []*rsa.PrivateKey, ks *initiator.KeySha
 	}
 	signature := sharesData[:signatureOffset]
 	msg := []byte("Hello")
-	if err := crypto.VerifyOwnerNoceSignature(signature, owner, validatorPublicKey, nonce); err != nil {
+	if err := crypto.VerifyOwnerNonceSignature(signature, owner, validatorPublicKey, nonce); err != nil {
 		return err
 	}
 	_ = utils.SplitBytes(sharesData[signatureOffset:pubKeysOffset], phase0.PublicKeyLength)

--- a/pkgs/utils/test_utils/test_utls.go
+++ b/pkgs/utils/test_utils/test_utls.go
@@ -45,9 +45,8 @@ func ParseAsError(msg []byte) (error, error) {
 }
 
 func CreateTestOperatorFromFile(t *testing.T, id uint64, examplePath string, version string) *TestOperator {
-	if err := logging.SetGlobalLogger("info", "capital", "console", nil); err != nil {
-		panic(err)
-	}
+	err := logging.SetGlobalLogger("info", "capital", "console", nil)
+	require.NoError(t, err)
 	logger := zap.L().Named("operator-tests")
 	priv, err := crypto.EncryptedPrivateKey(examplePath+"operator"+fmt.Sprintf("%v", id)+"/encrypted_private_key.json", "12345678")
 	require.NoError(t, err)
@@ -60,9 +59,7 @@ func CreateTestOperatorFromFile(t *testing.T, id uint64, examplePath string, ver
 	require.NoError(t, err)
 	operatorPubKey := priv.Public().(*rsa.PublicKey)
 	pkBytes, err := crypto.EncodePublicKey(operatorPubKey)
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
 	swtch := operator.NewSwitch(priv, logger, db, []byte(version), pkBytes, id)
 	s := &operator.Server{
 		Logger: logger,
@@ -80,9 +77,8 @@ func CreateTestOperatorFromFile(t *testing.T, id uint64, examplePath string, ver
 }
 
 func CreateTestOperator(t *testing.T, id uint64, version string) *TestOperator {
-	if err := logging.SetGlobalLogger("info", "capital", "console", nil); err != nil {
-		panic(err)
-	}
+	err := logging.SetGlobalLogger("info", "capital", "console", nil)
+	require.NoError(t, err)
 	logger := zap.L().Named("integration-tests")
 	_, pv, err := rsaencryption.GenerateKeys()
 	require.NoError(t, err)
@@ -97,9 +93,7 @@ func CreateTestOperator(t *testing.T, id uint64, version string) *TestOperator {
 	require.NoError(t, err)
 	operatorPubKey := priv.Public().(*rsa.PublicKey)
 	pkBytes, err := crypto.EncodePublicKey(operatorPubKey)
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
 	swtch := operator.NewSwitch(priv, logger, db, []byte(version), pkBytes, id)
 	s := &operator.Server{
 		Logger: logger,

--- a/pkgs/utils/utils.go
+++ b/pkgs/utils/utils.go
@@ -24,7 +24,7 @@ var ErrVersion = errors.New("wrong version")
 
 // WriteJSON writes data to JSON file
 func WriteJSON(filepath string, data any) error {
-	file, err := os.OpenFile(filepath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	file, err := os.OpenFile(filepath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
 	if err != nil {
 		return err
 	}

--- a/pkgs/wire/deals.go
+++ b/pkgs/wire/deals.go
@@ -19,7 +19,7 @@ func EncodeDealBundle(bundle *dkg.DealBundle) ([]byte, error) {
 	for _, p := range bundle.Public {
 		byts, err := p.MarshalBinary()
 		if err != nil {
-			panic(err.Error())
+			return nil, err
 		}
 		publics = append(publics, hex.EncodeToString(byts))
 	}

--- a/pkgs/wire/justification.go
+++ b/pkgs/wire/justification.go
@@ -17,7 +17,7 @@ func encodeJustifications(justifications []dkg.Justification) ([]encodedJustific
 	for _, j := range justifications {
 		byts, err := j.Share.MarshalBinary()
 		if err != nil {
-			panic(err.Error())
+			return nil, err
 		}
 
 		ret = append(ret, encodedJustification{


### PR DESCRIPTION
Fixes:

- Non-deterministic order in BLS signature recovery (Issue 6)
- Improper use of panic in error handling (Issue 10)
- Potential slowloris attack due to missing (Issue 11)
- x509.IsEncryptedPEMBlock/x509.DecryptPEMBlock are deprecated (Issue 8)
- Potential nil return when calling pem.EncodeToMemory  (Issue 5) 
- Missing nil check when calling pem.Decode function (Issue 4)
- Delayed handling of errors (Issue 9)
- RSA keys should be at least 2048 bits (Issue 1)