### PR TITLE
Bulk Validators Refactors

### DIFF
--- a/cli/initiator/reshare.go
+++ b/cli/initiator/reshare.go
@@ -43,6 +43,7 @@ var StartReshare = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		defer logger.Sync()
 		logger.Info("🪛 Initiator`s", zap.String("Version", cmd.Version))
 		opMap, err := cli_utils.LoadOperators(logger)
 		if err != nil {

--- a/cli/operator/operator.go
+++ b/cli/operator/operator.go
@@ -36,6 +36,7 @@ var StartDKGOperator = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		defer logger.Sync()
 		logger.Info("🪛 Operator`s", zap.String("Version", cmd.Version))
 		logger.Info("🔑 opening operator RSA private key file")
 		privateKey, err := cli_utils.OpenPrivateKey(cli_utils.PrivKeyPassword, cli_utils.PrivKey)

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/herumi/bls-eth-go-binary v1.29.1
 	github.com/imroc/req/v3 v3.37.2
 	github.com/pkg/errors v0.9.1
+	github.com/sourcegraph/conc v0.3.0
 	github.com/spf13/cobra v1.7.0
 	github.com/stretchr/testify v1.8.4
 	github.com/wealdtech/go-eth2-types/v2 v2.8.1

--- a/go.sum
+++ b/go.sum
@@ -397,6 +397,8 @@ github.com/shirou/gopsutil v3.21.11+incompatible h1:+1+c1VGhc88SSonWP6foOcLhvnKl
 github.com/shirou/gopsutil v3.21.11+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
+github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
+github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.9.5 h1:stMpOSZFs//0Lv29HduCmli3GUfpFoF3Y1Q/aXj/wVM=

--- a/pkgs/utils/utils.go
+++ b/pkgs/utils/utils.go
@@ -175,7 +175,7 @@ func CommitsToBytes(cs []kyber.Point) []byte {
 }
 
 func WriteErrorResponse(logger *zap.Logger, writer http.ResponseWriter, err error, statusCode int) {
-    logger.Error(err.Error())
-    writer.WriteHeader(statusCode)
-    writer.Write(wire.MakeErr(err))
+	logger.Error("request error: " + err.Error())
+	writer.WriteHeader(statusCode)
+	writer.Write(wire.MakeErr(err))
 }


### PR DESCRIPTION
- fix: increase `ReadHeaderTimeout` from 100ms to 10s (it caused init to fail >80% of the time with large validator counts)
- refactor: bounded concurrency in initiator with `conc/pool` package
- fix: don't ignore errors when reading request bodies
- refactor: re-use rate limit code