### PR TITLE
add full config to configpath flag

### DIFF
--- a/.k8/production/ssv-dkg/ssv-node-dkg-deployment-1.yml
+++ b/.k8/production/ssv-dkg/ssv-node-dkg-deployment-1.yml
@@ -58,7 +58,7 @@ spec:
             memory: REPLACE_NODES_MEM_LIMIT
         ports:
         - containerPort: 3030
-        command: ["/bin/ssv-dkg", "start-operator", "--configPath=/data/config", "--privKeyPassword=/data/password", "--privKey=/data/encrypted_private_key_op1.json"]
+        command: ["/bin/ssv-dkg", "start-operator", "--configPath=/data/config/config.yaml", "--privKeyPassword=/data/password", "--privKey=/data/encrypted_private_key_op1.json"]
         volumeMounts:
         - name: secrets-file
           mountPath: "/data/encrypted_private_key_op1.json"

--- a/.k8/production/ssv-dkg/ssv-node-dkg-deployment-2.yml
+++ b/.k8/production/ssv-dkg/ssv-node-dkg-deployment-2.yml
@@ -54,7 +54,7 @@ spec:
             memory: REPLACE_NODES_MEM_LIMIT
         ports:
         - containerPort: 3030
-        command: ["/bin/ssv-dkg", "start-operator", "--configPath=/data/config", "--privKeyPassword=/data/password", "--privKey=/data/encrypted_private_key_op2.json"]
+        command: ["/bin/ssv-dkg", "start-operator", "--configPath=/data/config/config.yaml", "--privKeyPassword=/data/password", "--privKey=/data/encrypted_private_key_op2.json"]
         volumeMounts:
         - name: secrets-file
           mountPath: "/data/encrypted_private_key_op2.json"

--- a/.k8/production/ssv-dkg/ssv-node-dkg-deployment-3.yml
+++ b/.k8/production/ssv-dkg/ssv-node-dkg-deployment-3.yml
@@ -54,7 +54,7 @@ spec:
             memory: REPLACE_NODES_MEM_LIMIT
         ports:
         - containerPort: 3030
-        command: ["/bin/ssv-dkg", "start-operator", "--configPath=/data/config", "--privKeyPassword=/data/password", "--privKey=/data/encrypted_private_key_op3.json"]
+        command: ["/bin/ssv-dkg", "start-operator", "--configPath=/data/config/config.yaml", "--privKeyPassword=/data/password", "--privKey=/data/encrypted_private_key_op3.json"]
         volumeMounts:
         - name: secrets-file
           mountPath: "/data/encrypted_private_key_op3.json"

--- a/.k8/production/ssv-dkg/ssv-node-dkg-deployment-4.yml
+++ b/.k8/production/ssv-dkg/ssv-node-dkg-deployment-4.yml
@@ -58,7 +58,7 @@ spec:
             memory: REPLACE_NODES_MEM_LIMIT
         ports:
         - containerPort: 3030
-        command: ["/bin/ssv-dkg", "start-operator", "--configPath=/data/config", "--privKeyPassword=/data/password", "--privKey=/data/encrypted_private_key_op4.json"]
+        command: ["/bin/ssv-dkg", "start-operator", "--configPath=/data/config/config.yaml", "--privKeyPassword=/data/password", "--privKey=/data/encrypted_private_key_op4.json"]
         volumeMounts:
         - name: secrets-file
           mountPath: "/data/encrypted_private_key_op4.json"


### PR DESCRIPTION
The nodes were in crashloop after the recent resharing PR was merged because the structure of the configflag was changed but the config flag provided in our k8s config wasn't updated. 

I updated it to the correct path.