### PR TITLE
refactor: deposit validation

### DIFF
--- a/cli/initiator/initiator.go
+++ b/cli/initiator/initiator.go
@@ -101,7 +101,7 @@ var StartDKG = &cobra.Command{
 		if err != nil {
 			logger.Fatal("😥 Failed to initiate DKG ceremony: ", zap.Error(err))
 		}
-		var depositDataArr []*initiator.DepositDataJson
+		var depositDataArr []*initiator.DepositDataCLI
 		var keySharesArr []*initiator.KeyShares
 		var ceremonySigsArr []*initiator.CeremonySigs
 		var nonces []uint64
@@ -137,7 +137,7 @@ var StartDKG = &cobra.Command{
 type Result struct {
 	id           [24]byte
 	nonce        uint64
-	depositData  *initiator.DepositDataJson
+	depositData  *initiator.DepositDataCLI
 	keyShares    *initiator.KeyShares
 	ceremonySigs *initiator.CeremonySigs
 }

--- a/cli/utils/utils.go
+++ b/cli/utils/utils.go
@@ -557,7 +557,7 @@ func LoadInitiatorRSAPrivKey(generate bool) (*rsa.PrivateKey, error) {
 	return privateKey, nil
 }
 
-func WriteInitResults(depositDataArr []*initiator.DepositDataJson, keySharesArr []*initiator.KeyShares, nonces []uint64, ceremonySigsArr []*initiator.CeremonySigs, logger *zap.Logger) {
+func WriteInitResults(depositDataArr []*initiator.DepositDataCLI, keySharesArr []*initiator.KeyShares, nonces []uint64, ceremonySigsArr []*initiator.CeremonySigs, logger *zap.Logger) {
 	if len(depositDataArr) != int(Validators) || len(keySharesArr) != int(Validators) {
 		logger.Fatal("Incoming result arrays have inconsistent length")
 	}
@@ -621,9 +621,9 @@ func WriteKeysharesResult(keyShares *initiator.KeyShares, dir string) error {
 	return nil
 }
 
-func WriteDepositResult(depositData *initiator.DepositDataJson, dir string) error {
+func WriteDepositResult(depositData *initiator.DepositDataCLI, dir string) error {
 	depositFinalPath := fmt.Sprintf("%s/deposit_data-0x%s.json", dir, depositData.PubKey)
-	err := utils.WriteJSON(depositFinalPath, []*initiator.DepositDataJson{depositData})
+	err := utils.WriteJSON(depositFinalPath, []*initiator.DepositDataCLI{depositData})
 	if err != nil {
 		return fmt.Errorf("failed writing deposit data file: %w, %v", err, depositData)
 	}

--- a/integration_test/integration_test.go
+++ b/integration_test/integration_test.go
@@ -74,7 +74,7 @@ func TestHappyFlows(t *testing.T) {
 		require.NoError(t, err)
 		err = testSharesData(ops, 4, []*rsa.PrivateKey{srv1.PrivKey, srv2.PrivKey, srv3.PrivKey, srv4.PrivKey}, sharesDataSigned, pubkeyraw, owner, 0)
 		require.NoError(t, err)
-		err = clnt.ValidateDepositJSON(depositData)
+		err = initiator.ValidateDepositDataCLI(depositData)
 		require.NoError(t, err)
 	})
 	t.Run("test 7 operators happy flow", func(t *testing.T) {
@@ -87,7 +87,7 @@ func TestHappyFlows(t *testing.T) {
 		require.NoError(t, err)
 		err = testSharesData(ops, 7, []*rsa.PrivateKey{srv1.PrivKey, srv2.PrivKey, srv3.PrivKey, srv4.PrivKey, srv5.PrivKey, srv6.PrivKey, srv7.PrivKey}, sharesDataSigned, pubkeyraw, owner, 0)
 		require.NoError(t, err)
-		err = clnt.ValidateDepositJSON(depositData)
+		err = initiator.ValidateDepositDataCLI(depositData)
 		require.NoError(t, err)
 	})
 	t.Run("test 10 operators happy flow", func(t *testing.T) {
@@ -100,7 +100,7 @@ func TestHappyFlows(t *testing.T) {
 		require.NoError(t, err)
 		err = testSharesData(ops, 10, []*rsa.PrivateKey{srv1.PrivKey, srv2.PrivKey, srv3.PrivKey, srv4.PrivKey, srv5.PrivKey, srv6.PrivKey, srv7.PrivKey, srv8.PrivKey, srv9.PrivKey, srv10.PrivKey}, sharesDataSigned, pubkeyraw, owner, 0)
 		require.NoError(t, err)
-		err = clnt.ValidateDepositJSON(depositData)
+		err = initiator.ValidateDepositDataCLI(depositData)
 		require.NoError(t, err)
 	})
 	t.Run("test 13 operators happy flow", func(t *testing.T) {
@@ -113,7 +113,7 @@ func TestHappyFlows(t *testing.T) {
 		require.NoError(t, err)
 		err = testSharesData(ops, 13, []*rsa.PrivateKey{srv1.PrivKey, srv2.PrivKey, srv3.PrivKey, srv4.PrivKey, srv5.PrivKey, srv6.PrivKey, srv7.PrivKey, srv8.PrivKey, srv9.PrivKey, srv10.PrivKey, srv11.PrivKey, srv12.PrivKey, srv13.PrivKey}, sharesDataSigned, pubkeyraw, owner, 0)
 		require.NoError(t, err)
-		err = clnt.ValidateDepositJSON(depositData)
+		err = initiator.ValidateDepositDataCLI(depositData)
 		require.NoError(t, err)
 	})
 	srv1.HttpSrv.Close()
@@ -312,7 +312,7 @@ func TestUnhappyFlows(t *testing.T) {
 	require.NoError(t, err)
 	err = testSharesData(ops, 4, []*rsa.PrivateKey{srv1.PrivKey, srv2.PrivKey, srv3.PrivKey, srv4.PrivKey}, sharesDataSigned, pubkeyraw, owner, 0)
 	require.NoError(t, err)
-	err = clnt.ValidateDepositJSON(depositData)
+	err = initiator.ValidateDepositDataCLI(depositData)
 	require.NoError(t, err)
 	marshalledKs, err := json.Marshal(ks)
 	require.NoError(t, err)
@@ -452,7 +452,7 @@ func TestReshareHappyFlow(t *testing.T) {
 		require.NoError(t, err)
 		err = testSharesData(ops, 4, []*rsa.PrivateKey{srv1.PrivKey, srv2.PrivKey, srv3.PrivKey, srv4.PrivKey}, sharesDataSigned, pubkeyraw, owner, 0)
 		require.NoError(t, err)
-		err = i.ValidateDepositJSON(depositData)
+		err = initiator.ValidateDepositDataCLI(depositData)
 		require.NoError(t, err)
 		newIds := []uint64{5, 6, 7, 8}
 		newId := crypto.NewID()
@@ -486,7 +486,7 @@ func TestReshareHappyFlow(t *testing.T) {
 		require.NoError(t, err)
 		err = testSharesData(ops, 4, []*rsa.PrivateKey{srv1.PrivKey, srv2.PrivKey, srv3.PrivKey, srv4.PrivKey}, sharesDataSigned, pubkeyraw, owner, 0)
 		require.NoError(t, err)
-		err = i.ValidateDepositJSON(depositData)
+		err = initiator.ValidateDepositDataCLI(depositData)
 		require.NoError(t, err)
 		newIds := []uint64{1, 7, 8, 9}
 		newId := crypto.NewID()
@@ -520,7 +520,7 @@ func TestReshareHappyFlow(t *testing.T) {
 		require.NoError(t, err)
 		err = testSharesData(ops, 4, []*rsa.PrivateKey{srv1.PrivKey, srv2.PrivKey, srv3.PrivKey, srv4.PrivKey}, sharesDataSigned, pubkeyraw, owner, 0)
 		require.NoError(t, err)
-		err = i.ValidateDepositJSON(depositData)
+		err = initiator.ValidateDepositDataCLI(depositData)
 		require.NoError(t, err)
 		newIds := []uint64{1, 2, 3, 4, 5, 8, 9}
 		newId := crypto.NewID()

--- a/pkgs/crypto/crypto.go
+++ b/pkgs/crypto/crypto.go
@@ -334,8 +334,8 @@ func SignDepositMessage(network e2m_core.Network, sk *bls.SecretKey, message *ph
 
 	// Sign.
 	sig := sk.SignByte(signingRoot[:])
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to sign the root")
+	if sig == nil {
+		return nil, fmt.Errorf("failed to sign the root")
 	}
 	var phase0Sig phase0.BLSSignature
 	copy(phase0Sig[:], sig.Serialize())
@@ -349,7 +349,7 @@ func SignDepositMessage(network e2m_core.Network, sk *bls.SecretKey, message *ph
 }
 
 // VerifyDepositData reconstructs and checks BLS signatures for ETH2 deposit message
-func VerifyDepositData(network e2m_core.Network, depositData *phase0.DepositData) error {
+func VerifyDepositData(network e2m_core.Network, depositData *phase0.DepositData, pubKey []byte) error {
 	// Compute DepositMessage root.
 	depositMessage := &phase0.DepositMessage{
 		PublicKey:             depositData.PublicKey,
@@ -375,9 +375,7 @@ func VerifyDepositData(network e2m_core.Network, depositData *phase0.DepositData
 	}
 
 	// Verify the signature.
-	pkCopy := make([]byte, len(depositData.PublicKey))
-	copy(pkCopy, depositData.PublicKey[:])
-	pubkey, err := types.BLSPublicKeyFromBytes(pkCopy)
+	pubkey, err := types.BLSPublicKeyFromBytes(pubKey)
 	if err != nil {
 		return fmt.Errorf("failed to parse public key: %s", err)
 	}

--- a/pkgs/dkg/drand.go
+++ b/pkgs/dkg/drand.go
@@ -390,7 +390,7 @@ func (o *LocalOwner) PostDKG(res *kyber_dkg.OptionResult) error {
 		Amount:                MaxEffectiveBalanceInGwei,
 	})
 	// Validate partial signature
-	if err := crypto.VerifyDepositData(network, depositData); err != nil {
+	if err := crypto.VerifyDepositData(network, depositData, secretKeyBLS.GetPublicKey().Serialize()); err != nil {
 		o.broadcastError(err)
 		return fmt.Errorf("failed to verify deposit data with partial signature: %w", err)
 	}

--- a/pkgs/initiator/deposit.go
+++ b/pkgs/initiator/deposit.go
@@ -1,0 +1,61 @@
+package initiator
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/bloxapp/eth2-key-manager/core"
+	"github.com/bloxapp/ssv-dkg/pkgs/dkg"
+)
+
+// DepositDataCLI  is a deposit structure from the eth2 deposit CLI (https://github.com/ethereum/staking-deposit-cli).
+type DepositDataCLI struct {
+	PubKey                string      `json:"pubkey"`
+	WithdrawalCredentials string      `json:"withdrawal_credentials"`
+	Amount                phase0.Gwei `json:"amount"`
+	Signature             string      `json:"signature"`
+	DepositMessageRoot    string      `json:"deposit_message_root"`
+	DepositDataRoot       string      `json:"deposit_data_root"`
+	ForkVersion           string      `json:"fork_version"`
+	NetworkName           string      `json:"network_name"`
+	DepositCliVersion     string      `json:"deposit_cli_version"`
+}
+
+// DepositCliVersion is last version accepted by launchpad
+const DepositCliVersion = "2.7.0"
+
+func BuildDepositDataCLI(network core.Network, depositData *phase0.DepositData, depositCLIVersion string) (*DepositDataCLI, error) {
+	depositMsg := &phase0.DepositMessage{
+		WithdrawalCredentials: depositData.WithdrawalCredentials,
+		Amount:                dkg.MaxEffectiveBalanceInGwei,
+	}
+	copy(depositMsg.PublicKey[:], depositData.PublicKey[:])
+	depositMsgRoot, err := depositMsg.HashTreeRoot()
+	if err != nil {
+		return nil, fmt.Errorf("failed to compute deposit message root: %v", err)
+	}
+
+	depositDataRoot, err := depositData.HashTreeRoot()
+	if err != nil {
+		return nil, fmt.Errorf("failed to compute deposit data root: %v", err)
+	}
+
+	// Final checks of prepared deposit data
+	if !(dkg.MaxEffectiveBalanceInGwei == depositData.Amount) {
+		return nil, fmt.Errorf("deposit data is invalid. Wrong amount %d", depositData.Amount)
+	}
+	forkbytes := network.GenesisForkVersion()
+	depositDataJson := &DepositDataCLI{
+		PubKey:                hex.EncodeToString(depositData.PublicKey[:]),
+		WithdrawalCredentials: hex.EncodeToString(depositData.WithdrawalCredentials),
+		Amount:                dkg.MaxEffectiveBalanceInGwei,
+		Signature:             hex.EncodeToString(depositData.Signature[:]),
+		DepositMessageRoot:    hex.EncodeToString(depositMsgRoot[:]),
+		DepositDataRoot:       hex.EncodeToString(depositDataRoot[:]),
+		ForkVersion:           hex.EncodeToString(forkbytes[:]),
+		NetworkName:           string(network),
+		DepositCliVersion:     depositCLIVersion,
+	}
+	return depositDataJson, nil
+}

--- a/pkgs/initiator/initiator.go
+++ b/pkgs/initiator/initiator.go
@@ -502,7 +502,7 @@ func (c *Initiator) reconstructAndVerifyDepositData(dkgResults []dkg.Result, ini
 	if err != nil {
 		return nil, err
 	}
-	shareRoot, err := crypto.ComputeDepositDataSigningRoot(network, &phase0.DepositMessage{
+	shareRoot, err := crypto.ComputeDepositMessageSigningRoot(network, &phase0.DepositMessage{
 		PublicKey:             phase0.BLSPubKey(validatorPubKey.Serialize()),
 		Amount:                dkg.MaxEffectiveBalanceInGwei,
 		WithdrawalCredentials: crypto.ETH1WithdrawalCredentials(init.WithdrawalCredentials)})
@@ -510,7 +510,7 @@ func (c *Initiator) reconstructAndVerifyDepositData(dkgResults []dkg.Result, ini
 		return nil, fmt.Errorf("failed to compute deposit data root: %v", err)
 	}
 	// Verify partial signatures and recovered threshold signature
-	err = crypto.VerifyPartialSigs(shareSigs, sharePks, shareRoot)
+	err = crypto.VerifyPartialSigs(shareSigs, sharePks, shareRoot[:])
 	if err != nil {
 		return nil, fmt.Errorf("failed to verify partial signatures: %v", err)
 	}

--- a/pkgs/operator/state.go
+++ b/pkgs/operator/state.go
@@ -469,7 +469,7 @@ func (s *Switch) SaveResultData(incMsg *wire.SignedTransport) error {
 			return err
 		}
 	}
-	var depJson *initiator.DepositDataJson
+	var depJson *initiator.DepositDataCLI
 	if len(resData.DepositData) != 0 {
 		err = json.Unmarshal(resData.DepositData, &depJson)
 		if err != nil {

--- a/pkgs/utils/utils.go
+++ b/pkgs/utils/utils.go
@@ -99,16 +99,16 @@ func JoinSets(oldOperators, newOperators []*wire.Operator) []*wire.Operator {
 // GetNetworkByFork translates the network fork bytes into name
 //
 //	TODO: once eth2_key_manager implements this we can get rid of it and support all networks ekm supports automatically
-func GetNetworkByFork(fork [4]byte) eth2_key_manager_core.Network {
+func GetNetworkByFork(fork [4]byte) (eth2_key_manager_core.Network, error) {
 	switch fork {
 	case [4]byte{0x00, 0x00, 0x10, 0x20}:
-		return eth2_key_manager_core.PraterNetwork
+		return eth2_key_manager_core.PraterNetwork, nil
 	case [4]byte{0x01, 0x01, 0x70, 0x00}:
-		return eth2_key_manager_core.HoleskyNetwork
+		return eth2_key_manager_core.HoleskyNetwork, nil
 	case [4]byte{0, 0, 0, 0}:
-		return eth2_key_manager_core.MainNetwork
+		return eth2_key_manager_core.MainNetwork, nil
 	default:
-		return eth2_key_manager_core.MainNetwork
+		return eth2_key_manager_core.MainNetwork, errors.New("unknown network")
 	}
 }
 


### PR DESCRIPTION
- Added deposit data tests (for mainnet & prater)
- Less error ignores
- More code re-use

TODO:
- [ ] Extract deposit data signing root computation instead of passing pubkey in VerifyDepositData function.