### PR TITLE
fix: invalid ceremony dir name (usage of `:`)

### DIFF
--- a/cli/utils/utils.go
+++ b/cli/utils/utils.go
@@ -447,12 +447,12 @@ func WriteResults(
 	}
 
 	// Create the ceremony directory.
-	timestamp := time.Now().UTC().Format("2006-01-02T15:04:05.000Z07:00")
+	timestamp := time.Now().UTC().Format("2006-01-02--15-04-05.000")
 	randomness := make([]byte, 4)
 	if _, err := rand.Read(randomness); err != nil {
 		return fmt.Errorf("failed to generate randomness: %w", err)
 	}
-	dir := filepath.Join(outputPath, fmt.Sprintf("ceremony-%s-%x", timestamp, randomness))
+	dir := filepath.Join(outputPath, fmt.Sprintf("ceremony-%s--%x", timestamp, randomness))
 	err = os.Mkdir(dir, os.ModePerm)
 	if os.IsExist(err) {
 		return fmt.Errorf("ceremony directory already exists: %w", err)


### PR DESCRIPTION
While it's possible to save a file containing `:`, it's sometimes an illegal character for filenames in various operating systems and file explorers.

As @andrew-blox recently noticed that Finder shows our ceremony directory names with`/` instead of `:` which makes it impossible to copy the folder name from Finder into terminal since it's displayed differently in both.