### PR TITLE
4.1 Arbitrary Path Access

### DIFF
--- a/cli/utils/utils.go
+++ b/cli/utils/utils.go
@@ -95,8 +95,6 @@ func SetViperConfig(cmd *cobra.Command) error {
 		if err := viper.ReadInConfig(); err != nil {
 			return err
 		}
-	} else {
-		return fmt.Errorf("😥 wrong configPath")
 	}
 	return nil
 }
@@ -302,15 +300,15 @@ func BindInitiatorBaseFlags(cmd *cobra.Command) error {
 		return fmt.Errorf("😥 Operator IDs flag cant be empty")
 	}
 	OperatorsInfoPath = viper.GetString("operatorsInfoPath")
-	if !filepath.IsLocal(OperatorsInfoPath) {
-		return fmt.Errorf("😥 wrong operatorsInfoPath flag")
-	}
 	OperatorsInfo = viper.GetString("operatorsInfo")
 	if OperatorsInfoPath != "" && OperatorsInfo != "" {
 		return fmt.Errorf("😥 operators info can be provided either as a raw JSON string, or path to a file, not both")
 	}
 	if OperatorsInfoPath == "" && OperatorsInfo == "" {
 		return fmt.Errorf("😥 operators info should be provided either as a raw JSON string, or path to a file")
+	}
+	if OperatorsInfoPath != "" && !filepath.IsLocal(OperatorsInfoPath) {
+		return fmt.Errorf("😥 wrong operatorsInfoPath flag")
 	}
 	owner := viper.GetString("owner")
 	if owner == "" {
@@ -407,15 +405,15 @@ func BindResigningFlags(cmd *cobra.Command) error {
 		return fmt.Errorf("😥 Operator IDs flag cant be empty")
 	}
 	OperatorsInfoPath = viper.GetString("operatorsInfoPath")
-	if !filepath.IsLocal(OperatorsInfoPath) {
-		return fmt.Errorf("😥 wrong operatorsInfoPath flag")
-	}
 	OperatorsInfo = viper.GetString("operatorsInfo")
 	if OperatorsInfoPath != "" && OperatorsInfo != "" {
 		return fmt.Errorf("😥 operators info can be provided either as a raw JSON string, or path to a file, not both")
 	}
 	if OperatorsInfoPath == "" && OperatorsInfo == "" {
 		return fmt.Errorf("😥 operators info should be provided either as a raw JSON string, or path to a file")
+	}
+	if OperatorsInfoPath != "" && !filepath.IsLocal(OperatorsInfoPath) {
+		return fmt.Errorf("😥 wrong operatorsInfoPath flag")
 	}
 	owner := viper.GetString("owner")
 	if owner == "" {
@@ -502,15 +500,15 @@ func BindReshareFlags(cmd *cobra.Command) error {
 		return err
 	}
 	OperatorsInfoPath = viper.GetString("operatorsInfoPath")
-	if !filepath.IsLocal(OperatorsInfoPath) {
-		return fmt.Errorf("😥 wrong operatorsInfoPath flag")
-	}
 	OperatorsInfo = viper.GetString("operatorsInfo")
 	if OperatorsInfoPath != "" && OperatorsInfo != "" {
 		return fmt.Errorf("😥 operators info can be provided either as a raw JSON string, or path to a file, not both")
 	}
 	if OperatorsInfoPath == "" && OperatorsInfo == "" {
 		return fmt.Errorf("😥 operators info should be provided either as a raw JSON string, or path to a file")
+	}
+	if OperatorsInfoPath != "" && !filepath.IsLocal(OperatorsInfoPath) {
+		return fmt.Errorf("😥 wrong operatorsInfoPath flag")
 	}
 	OperatorIDs = viper.GetStringSlice("operatorIDs")
 	if len(OperatorIDs) == 0 {


### PR DESCRIPTION
*Problem:* In cli/utils/utils.go at line 260, the tool defends against path traversal. However, OutputPath could be an absolute path, such as /etc/passwd, defeating the defense. Severity is informational since in our model, the configuration values are not controlled by an adversary. This also applies to ConfigPath, LogFilePath, OperatorsInfoPath, elements of ClientCACertPath, ProofsFilePath, KeystorePath, ServerTLSCertPath, ServerTLSKeyPath, and CeremonyDir.

*Solution:* use filepath.IsLocal 

```
filepath.IsLocal("/foo") // false: is an absolute path
filepath.IsLocal("../foo") // false: is not within the subtree rooted at the directory in which path is evaluated
filepath.IsLocal("") // false: is empty
filepath.IsLocal("foo/bar") // true
```