### PR TITLE
chore: add Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,5 @@
 {
+  "baseBranches": ["unstable"],
   "extends": [
     "github>ssvlabs/shared-configs//renovate/renovate.json"
   ]


### PR DESCRIPTION
This PR adds a Renovate config extending `ssvlabs/shared-configs`.