### PR TITLE
Replace error text with error code

### DIFF
--- a/pkgs/dkg/drand.go
+++ b/pkgs/dkg/drand.go
@@ -531,7 +531,7 @@ func (o *LocalOwner) broadcastError(err error) {
 	errMsg := &wire.Transport{
 		Type:       wire.ErrorMessageType,
 		Identifier: o.data.reqID,
-		Data:       wire.EncodeInitiatorErrorCode(wire.InitiatorErrorCodeCeremonyFailed),
+		Data:       wire.InitiatorErrorCodeCeremonyFailed.Encode(),
 		Version:    o.version,
 	}
 

--- a/pkgs/dkg/drand.go
+++ b/pkgs/dkg/drand.go
@@ -520,7 +520,8 @@ func CreateExchange(pk kyber.Point, commits []byte) ([]byte, *wire.Exchange, err
 	return exchByts, &exch, nil
 }
 
-// broadcastError propagates the error at operator back to initiator
+// broadcastError logs the internal error and sends a generic error code back to
+// the initiator.
 func (o *LocalOwner) broadcastError(err error) {
 	o.Logger.Error(
 		"dkg ceremony failed",

--- a/pkgs/dkg/drand.go
+++ b/pkgs/dkg/drand.go
@@ -3,7 +3,6 @@ package dkg
 import (
 	"bytes"
 	"crypto/rsa"
-	"encoding/json"
 	"fmt"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
@@ -523,15 +522,16 @@ func CreateExchange(pk kyber.Point, commits []byte) ([]byte, *wire.Exchange, err
 
 // broadcastError propagates the error at operator back to initiator
 func (o *LocalOwner) broadcastError(err error) {
-	errMsgEnc, err := json.Marshal(err.Error())
-	if err != nil {
-		o.Logger.Error("failed to marshal error message", zap.Error(err))
-		return
-	}
+	o.Logger.Error(
+		"dkg ceremony failed",
+		zap.Error(err),
+		zap.Uint64("operator_id", o.ID),
+		zap.String("reqid", fmt.Sprintf("%x", o.data.reqID[:])),
+	)
 	errMsg := &wire.Transport{
 		Type:       wire.ErrorMessageType,
 		Identifier: o.data.reqID,
-		Data:       errMsgEnc,
+		Data:       wire.EncodeInitiatorErrorCode(wire.InitiatorErrorCodeCeremonyFailed),
 		Version:    o.version,
 	}
 

--- a/pkgs/initiator/initiator.go
+++ b/pkgs/initiator/initiator.go
@@ -986,7 +986,7 @@ func (c *Initiator) createBulkResults(resultsBytes [][][]byte, signedMsg, msgIDM
 func verifyMessageType(tsp *wire.SignedTransport, expectedType wire.TransportType) error {
 	if tsp.Message.Type != expectedType {
 		if tsp.Message.Type == wire.ErrorMessageType {
-			return fmt.Errorf("dkg protocol failed with %s", wire.DecodeInitiatorErrorMessage(tsp.Message.Data))
+			return fmt.Errorf("dkg protocol failed with %s", wire.ParseInitiatorErrorMessage(tsp.Message.Data))
 		}
 		if tsp.Message.Type == wire.KyberMessageType {
 			kyberMsg := &wire.KyberMessage{}

--- a/pkgs/initiator/initiator.go
+++ b/pkgs/initiator/initiator.go
@@ -986,7 +986,7 @@ func (c *Initiator) createBulkResults(resultsBytes [][][]byte, signedMsg, msgIDM
 func verifyMessageType(tsp *wire.SignedTransport, expectedType wire.TransportType) error {
 	if tsp.Message.Type != expectedType {
 		if tsp.Message.Type == wire.ErrorMessageType {
-			return fmt.Errorf("dkg protocol failed with %s", string(tsp.Message.Data))
+			return fmt.Errorf("dkg protocol failed with %s", wire.DecodeInitiatorErrorMessage(tsp.Message.Data))
 		}
 		if tsp.Message.Type == wire.KyberMessageType {
 			kyberMsg := &wire.KyberMessage{}

--- a/pkgs/operator/handlers.go
+++ b/pkgs/operator/handlers.go
@@ -27,6 +27,10 @@ func sanitizeCeremonyError(err error) error {
 	return err
 }
 
+func sanitizeReshareError(err error) error {
+	return &utils.SensitiveError{Err: err, PresentedErr: string(wire.InitiatorErrorCodeCeremonyFailed)}
+}
+
 func (s *Server) resultsHandler(writer http.ResponseWriter, request *http.Request) {
 	signedResultMsg, err := processIncomingRequest(writer, request, wire.ResultMessageType, s.State.OperatorID)
 	if err != nil {
@@ -157,7 +161,7 @@ func (s *Server) signedReshareHandler(writer http.ResponseWriter, request *http.
 	if err != nil {
 		logger.Error("error resharing instance", zap.Error(err))
 		respErr := fmt.Errorf("operator %d, err: %w", s.State.OperatorID, err)
-		utils.WriteErrorResponse(s.Logger, writer, sanitizeCeremonyError(respErr), http.StatusBadRequest)
+		utils.WriteErrorResponse(s.Logger, writer, sanitizeReshareError(respErr), http.StatusBadRequest)
 		return
 	}
 	logger.Info("✅ Reshare instance created successfully")

--- a/pkgs/operator/handlers.go
+++ b/pkgs/operator/handlers.go
@@ -1,6 +1,7 @@
 package operator
 
 import (
+	"crypto/rsa"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -15,6 +16,13 @@ import (
 func sanitizeRequestError(err error) error {
 	if errors.Is(err, errRequestBodyTooLarge) {
 		return &utils.SensitiveError{Err: err, PresentedErr: "request body too large"}
+	}
+	return err
+}
+
+func sanitizeCeremonyError(err error) error {
+	if errors.Is(err, rsa.ErrDecryption) {
+		return &utils.SensitiveError{Err: err, PresentedErr: string(wire.InitiatorErrorCodeCeremonyFailed)}
 	}
 	return err
 }
@@ -62,7 +70,9 @@ func (s *Server) dkgHandler(writer http.ResponseWriter, request *http.Request) {
 	}
 	b, err := s.State.ProcessMessage(rawdata)
 	if err != nil {
-		utils.WriteErrorResponse(s.Logger, writer, fmt.Errorf("operator %d, err: %w", s.State.OperatorID, err), http.StatusBadRequest)
+		s.Logger.Error("error processing dkg message", zap.Error(err), zap.Uint64("operator_id", s.State.OperatorID))
+		respErr := fmt.Errorf("operator %d, err: %w", s.State.OperatorID, err)
+		utils.WriteErrorResponse(s.Logger, writer, sanitizeCeremonyError(respErr), http.StatusBadRequest)
 		return
 	}
 	writer.WriteHeader(http.StatusOK)
@@ -87,8 +97,9 @@ func (s *Server) initHandler(writer http.ResponseWriter, request *http.Request) 
 	logger.Debug("creating instance with init message data")
 	b, err := s.State.InitInstance(reqid, signedInitMsg.Message, signedInitMsg.Signer, signedInitMsg.Signature)
 	if err != nil {
-		s.Logger.Error("Error creating instance", zap.Error(err))
-		utils.WriteErrorResponse(s.Logger, writer, fmt.Errorf("operator %d, failed to initialize instance, err: %w", s.State.OperatorID, err), http.StatusBadRequest)
+		logger.Error("error creating instance", zap.Error(err))
+		respErr := fmt.Errorf("operator %d, failed to initialize instance, err: %w", s.State.OperatorID, err)
+		utils.WriteErrorResponse(s.Logger, writer, sanitizeCeremonyError(respErr), http.StatusBadRequest)
 		return
 	}
 	logger.Info("✅ Instance started successfully")
@@ -115,8 +126,9 @@ func (s *Server) signedResignHandler(writer http.ResponseWriter, request *http.R
 	logger := s.Logger.With(zap.String("reqid", hex.EncodeToString(reqid[:])))
 	b, err := s.State.HandleInstanceOperation(reqid, signedResignMsg.Message, signedResignMsg.Signer, signedResignMsg.Signature, "resign")
 	if err != nil {
-		s.Logger.Error("Error resigning instance", zap.Error(err))
-		utils.WriteErrorResponse(s.Logger, writer, fmt.Errorf("operator %d, failed to resign, err: %w", s.State.OperatorID, err), http.StatusBadRequest)
+		logger.Error("error resigning instance", zap.Error(err))
+		respErr := fmt.Errorf("operator %d, failed to resign, err: %w", s.State.OperatorID, err)
+		utils.WriteErrorResponse(s.Logger, writer, sanitizeCeremonyError(respErr), http.StatusBadRequest)
 		return
 	}
 	logger.Info("✅ resigned data successfully")
@@ -143,7 +155,9 @@ func (s *Server) signedReshareHandler(writer http.ResponseWriter, request *http.
 	logger := s.Logger.With(zap.String("reqid", hex.EncodeToString(reqid[:])))
 	b, err := s.State.HandleInstanceOperation(reqid, signedReshareMsg.Message, signedReshareMsg.Signer, signedReshareMsg.Signature, "reshare")
 	if err != nil {
-		utils.WriteErrorResponse(s.Logger, writer, fmt.Errorf("operator %d, err: %w", s.State.OperatorID, err), http.StatusBadRequest)
+		logger.Error("error resharing instance", zap.Error(err))
+		respErr := fmt.Errorf("operator %d, err: %w", s.State.OperatorID, err)
+		utils.WriteErrorResponse(s.Logger, writer, sanitizeCeremonyError(respErr), http.StatusBadRequest)
 		return
 	}
 	logger.Info("✅ Reshare instance created successfully")

--- a/pkgs/wire/initiator_error.go
+++ b/pkgs/wire/initiator_error.go
@@ -11,17 +11,17 @@ const (
 	InitiatorErrorCodeCeremonyFailed InitiatorErrorCode = "CEREMONY_FAILED"
 )
 
-// EncodeInitiatorErrorCode JSON-marshals the error code for transport.
-func EncodeInitiatorErrorCode(code InitiatorErrorCode) []byte {
+// Encode JSON-marshals the error code for transport.
+func (code InitiatorErrorCode) Encode() []byte {
 	// Marshaling a string cannot fail; ignore the error for simplicity.
 	encoded, _ := json.Marshal(code)
 	return encoded
 }
 
-// DecodeInitiatorErrorMessage attempts to decode a JSON-marshaled string. If it
+// ParseInitiatorErrorMessage attempts to decode a JSON-marshaled string. If it
 // fails, it falls back to returning the raw payload as a string (backwards
 // compatible with any legacy non-JSON payloads).
-func DecodeInitiatorErrorMessage(data []byte) string {
+func ParseInitiatorErrorMessage(data []byte) string {
 	var decoded string
 	if err := json.Unmarshal(data, &decoded); err == nil {
 		return decoded

--- a/pkgs/wire/initiator_error.go
+++ b/pkgs/wire/initiator_error.go
@@ -1,0 +1,30 @@
+package wire
+
+import "encoding/json"
+
+// InitiatorErrorCode is a stable error code intended to be sent over the wire to
+// the ceremony initiator. It must not include internal failure details.
+type InitiatorErrorCode string
+
+const (
+	// InitiatorErrorCodeCeremonyFailed is the generic failure code for any ceremony failure.
+	InitiatorErrorCodeCeremonyFailed InitiatorErrorCode = "CEREMONY_FAILED"
+)
+
+// EncodeInitiatorErrorCode JSON-marshals the error code for transport.
+func EncodeInitiatorErrorCode(code InitiatorErrorCode) []byte {
+	// Marshaling a string cannot fail; ignore the error for simplicity.
+	encoded, _ := json.Marshal(code)
+	return encoded
+}
+
+// DecodeInitiatorErrorMessage attempts to decode a JSON-marshaled string. If it
+// fails, it falls back to returning the raw payload as a string (backwards
+// compatible with any legacy non-JSON payloads).
+func DecodeInitiatorErrorMessage(data []byte) string {
+	var decoded string
+	if err := json.Unmarshal(data, &decoded); err == nil {
+		return decoded
+	}
+	return string(data)
+}

--- a/pkgs/wire/initiator_error_test.go
+++ b/pkgs/wire/initiator_error_test.go
@@ -1,0 +1,18 @@
+package wire
+
+import "testing"
+
+func TestEncodeDecodeInitiatorErrorCode_RoundTrip(t *testing.T) {
+	encoded := EncodeInitiatorErrorCode(InitiatorErrorCodeCeremonyFailed)
+	decoded := DecodeInitiatorErrorMessage(encoded)
+	if decoded != string(InitiatorErrorCodeCeremonyFailed) {
+		t.Fatalf("expected %q, got %q", InitiatorErrorCodeCeremonyFailed, decoded)
+	}
+}
+
+func TestDecodeInitiatorErrorMessage_FallbackRawBytes(t *testing.T) {
+	decoded := DecodeInitiatorErrorMessage([]byte("CEREMONY_FAILED"))
+	if decoded != "CEREMONY_FAILED" {
+		t.Fatalf("expected %q, got %q", "CEREMONY_FAILED", decoded)
+	}
+}

--- a/pkgs/wire/initiator_error_test.go
+++ b/pkgs/wire/initiator_error_test.go
@@ -1,18 +1,18 @@
 package wire
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 func TestEncodeDecodeInitiatorErrorCode_RoundTrip(t *testing.T) {
-	encoded := EncodeInitiatorErrorCode(InitiatorErrorCodeCeremonyFailed)
-	decoded := DecodeInitiatorErrorMessage(encoded)
-	if decoded != string(InitiatorErrorCodeCeremonyFailed) {
-		t.Fatalf("expected %q, got %q", InitiatorErrorCodeCeremonyFailed, decoded)
-	}
+	encoded := InitiatorErrorCodeCeremonyFailed.Encode()
+	decoded := ParseInitiatorErrorMessage(encoded)
+	require.Equal(t, string(InitiatorErrorCodeCeremonyFailed), decoded)
 }
 
-func TestDecodeInitiatorErrorMessage_FallbackRawBytes(t *testing.T) {
-	decoded := DecodeInitiatorErrorMessage([]byte("CEREMONY_FAILED"))
-	if decoded != "CEREMONY_FAILED" {
-		t.Fatalf("expected %q, got %q", "CEREMONY_FAILED", decoded)
-	}
+func TestParseInitiatorErrorMessage_FallbackRawBytes(t *testing.T) {
+	decoded := ParseInitiatorErrorMessage([]byte("CEREMONY_FAILED"))
+	require.Equal(t, "CEREMONY_FAILED", decoded)
 }


### PR DESCRIPTION
Fix for:

F-ssv-dkg-006 P1 Triaged
Internal Error Messages Broadcast to Initiator
ssv-dkg · Security · Assigned: dev4 · Effort: —
Internal error messages (including cryptographic failure details like "failed to decrypt", "invalid padding") are JSON-marshaled and broadcast to the initiator via `wire.ErrorMessageType`. When combined with PKCS#1 v1.5 encryption [HIGH-1], these error messages can serve as a padding oracle.

Impact: Enables Bleichenbacher-style adaptive chosen-ciphertext attacks against encrypted BLS shares.

Recommendation: Broadcast generic error codes only (e.g., "ceremony failed"). Log detailed errors server-side.