### PR TITLE
Fix healthcheck pong signature verification (use known operator RSA key)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,27 +93,27 @@ Operators info file example:
   {
     "id": 143,
     "public_key": "LS0tLS1CRUdJTiBSU0EgUFVCTElDIEtFWS0tLS0tCk1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBTUlJQkNnS0NBUUVBM2VyQk9IUTVJYkJmL3lxak1UMmYKNElQYWJBMkY4YmwzQWlJVStRQlBUd2s2UFRRZS9EZVZMVkx6cm5wWFdZemNTRUZVSnZZeU5WM3ZhYkxGN2VDZwpxNlptRUJhSHN5S2NYS0g5N0JCb21VaDF4TGl5OFRGTkk0VGdjL0JwSU51dEdrRGkrVUhCT0tBcHE0TUVaSXlsCnJpTHlaeDFNZnJ6QTF0ZUNRaVJ3T2tzN0wrT1IraElNOEwvNFRtTUd4RDFhS2tXOHhpUzlKL256YXB5YkxsczMKR3cwWER0Q25XLzREWFVLSm1wLzFrMHlNeHZjT1phUjJWSjB0aUFVMjBKNDcrcUtndi9kZHI1YjNjQ2F5NDhpVQptcks2MkNEaHdyNVpqaU1WSHg2R1NJK0kvZmhMckI2Z2dSdTBYVVVFYTljNzVvR3k1SHVKSFA5dTJIQ0dZSXI5CjBRSURBUUFCCi0tLS0tRU5EIFJTQSBQVUJMSUMgS0VZLS0tLS0K",
-    "ip": "http://141.94.143.182:3030"
+    "ip": "https://141.94.143.182:3030"
   },
   {
     "id": 219,
     "public_key": "LS0tLS1CRUdJTiBSU0EgUFVCTElDIEtFWS0tLS0tCk1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBTUlJQkNnS0NBUUVBcjNlTjVhR205NTN5U0VrcHBDZnAKZmp2bFpMaG51Y0c2ajI2emxHYjNobHcvVXE5aG9tSmhzOVUzTHFuYzU4dk5RR2pENzhCTUZOMy8xUStXanZRSgpuQVJJVVdJTnJONWNoMFBTMXBqb21CVlB0Nkg0RE5ha1lSamxCM0V0QmZGaGFOcDdlQzd4dGFMbzc3Qk5velMxCjBBOFpSRC9IaGg3T3lkNWttUWVnV1pIOGlGRCszcHZnV1ZMUWFibkZuK00xWW9LYUhDNkRHSzdnSzdEYTRlMGcKUTF4MFRhSmRZMUUvcStUQ01oUGhwcmtoVlFlNFBLU0NKOWJHSnRDblBpRUFqa2VWa09RZlA0Z095b0VjaW5jMQpTR2pveVo1dVZPU1hEZGYzVzdYUE9pZEpFU1VoY1hqS05DMC9IN09ZM2pqdTZyUU9NZmFqSERhb3VSWEJGaHZDCnp3SURBUUFCCi0tLS0tRU5EIFJTQSBQVUJMSUMgS0VZLS0tLS0K",
-    "ip": "http://209.35.77.243:12015"
+    "ip": "https://209.35.77.243:12015"
   },
   {
     "id": 33,
     "public_key": "LS0tLS1CRUdJTiBSU0EgUFVCTElDIEtFWS0tLS0tCk1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBTUlJQkNnS0NBUUVBdmo5UmpQTFk5YXd1WVc3NVRVcVoKVWozRWRMN2NkdDFnUjlydHowQU02TENNbTdCNG5DcW1RYjRCeFBsUktVeVl1ZnNEbXIzeTVqUmdVbHBHR0ZRawpOWmU0VGRZQkxPNnRUZ1NyMXphMUlGR0R2dzdJUUJZSHoramFEYVN6Zk9vYnNiUldiMDVaZFdGc01keGlEam5vCnR2NHZ4eGpCOWlXa2xmaytUNXB4K3ZwTWZnd1M2Ui9EOU84Y0dZdTg1b0RpQXgzQ0tPampuY3BPV0pndHhxZUMKbENDbldxSS9PeTFSa1FVcFNYL1hsRHozSHhCN0NlY0IzeUUwNnNTbXd1WTZHdk9tMUEvMmdNVUprbDFTUmFjbgpDeFhYK1hVWWFEemZGdXBBeWxPVnIxMEFnUkpTcVd2SkoxcnJCZkFwSzBMNzFMQzFzVzRyWjloMGFIN2pweW1aCjF3SURBUUFCCi0tLS0tRU5EIFJTQSBQVUJMSUMgS0VZLS0tLS0K",
-    "ip": "http://51.81.109.67:3030"
+    "ip": "https://51.81.109.67:3030"
   },
   {
     "id": 190,
     "public_key": "LS0tLS1CRUdJTiBSU0EgUFVCTElDIEtFWS0tLS0tCk1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBTUlJQkNnS0NBUUVBeEowZDYxN09BSHpxOUQzTUt2WFoKTEJRR2VzVU4xZGFXOC9MNEt4UWJFVlN6Y2JzTlY1Q1RqNm5OWGtnOW1LQzIyWWRRazRZcGpNbk9reENrMXNXRApvUXI4bG4zZTJxbU9zeHJuOGFxZEJhVGZmaFZ4WDJrTU9BZUZCcEJPN0lrTXBOUTFwMzdDMzh0Rmx0eFpxSEt3CkFJVXg5UjVGWWhOZXhrOEUrQlpMYzJFSzl4bjZIMTFUY21hN2NVZW03VUpDeUR3VFlLVC9JN21ZTXV3UGFpTTAKTm1Ta0JoeFYrdkd3bmJqWWhCaEZQTi9MMTJRWi9YZUVJcHFzcGRKTFpkUmhRd2VlZG1MdTNLcXdFdnhhNEJZVQpWcTlkeG9qd1JDdU9TL2tvM1pTQ3hubWpJaHlGQUJXYW5WU2x5TW5xdGFaZTFkdm1STG12RTFpL3RjN251MnRnCi93SURBUUFCCi0tLS0tRU5EIFJTQSBQVUJMSUMgS0VZLS0tLS0K",
-    "ip": "http://80.181.85.114:3030"
+    "ip": "https://80.181.85.114:3030"
   },
   {
     "id": 34,
     "public_key": "LS0tLS1CRUdJTiBSU0EgUFVCTElDIEtFWS0tLS0tCk1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBTUlJQkNnS0NBUUVBNHZMUm93Ry9HeVFYdnFaS092MzEKYlNkRVFId3FoTmR2d2JCckdyYlQ0dmVWVHNPbDNPRVF6K3dWMjBVaXJjeHBVVVRKc081K0wrTzlnR0xNMWdTRgpFMVJRU01zMXEzSkZtNlY0VXFQU3pMK09DcDlMS3ZIRnJKMmU4VGwyZ25UU0tPNzFncGtUdFRrb2ZlLzlJRjFOCmNZMDlJbkQwTWNtZzk1Qm14alBuREV3VE1uVzBQU3JVTnJQYVNlMTJTVHJ0Q2JCTUJFUFR5RnI5elovRWFESFIKSHFaZjlkeE9VMjBiQnNSUVlSMnhCZFBtWHFKaFZZMTQrOExmaWpLRmhMcDNmZ25IL0xtK0NjTE5FOFQ3ZjhTTApoZUhLcnMrcUV4VERTcDR4MWhLMzk4dnpWTElOL0h6T20yeXV3Z3cxeG9zdThTOFlVUzNCeTFGZ3g2RExZc3RyCmxRSURBUUFCCi0tLS0tRU5EIFJTQSBQVUJMSUMgS0VZLS0tLS0K",
-    "ip": "http://148.113.20.206:3030"
+    "ip": "https://148.113.20.206:3030"
   }
 ]
 ```
@@ -123,16 +123,24 @@ Operators info file example:
 Before initiate a DKG ceremony it's advised to check if all participating operators are online and healthy.
 
 ```sh
+docker run --name ssv_dkg_health -v "<PATH_TO_OPERATORS_INFO_FILE_DIR>":/data -it \
+"ssvlabs/ssv-dkg:latest" ping --operatorsInfoPath /data/operators_info.json && \
+docker rm ssv_dkg_health
+```
+
+To ping only a subset of operators, pass their endpoints explicitly:
+
+```sh
 docker run --name ssv_dkg_health \
-"ssvlabs/ssv-dkg:latest" ping --ip http://141.94.143.182:3030,http://209.35.77.243:12015,http://51.81.109.67:3030,http://80.181.85.114:3030,http://148.113.20.206:3030 && \
+"ssvlabs/ssv-dkg:latest" ping --operatorsInfoPath /data/operators_info.json --ip https://141.94.143.182:3030,https://209.35.77.243:12015,https://51.81.109.67:3030,https://80.181.85.114:3030,https://148.113.20.206:3030 && \
 docker rm ssv_dkg_health
 ```
 
 Result should look like this:
 
 ```sh
-2024-03-21T10:19:24.589162Z	INFO	dkg-initiator	🍎 operator online and healthy	{"ID": "416", "IP": "http://141.94.143.182:3030", "Version": "v1.0.3", "Public key": "LS0tLS1CRUdJTiBSU0EgUFVCTElDIEtFWS0tLS0tCk1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBTUlJQkNnS0NBUUVBeHVDaUY2MW5zdTd1MEZhdUZBb1kKWll5ODA0eExENzVuMU0vYjNYTHpaZFpSWUF2aVVyeWJ3Z1gwTEFPRWhPcVIwN0QzTXV3REg0bVhUaXI2Qyt1eQpYaHpVYmFiZXd4V1NDUUtvOFBLSkZWbWxBenh1dHlTb0tPajEvdStnNGgzeHlvMkhsY0M4aERpU3pjdjZXSERtCnhxTjBKcnpHRjU2VmdGMm9EaWsrejBuMmJadDdRMDJWTWVSRnQzamc0dWdzYjY5OEF4aHdFQ3VLYVo4WjZpT3IKT2lIbzdoQUtMaGo5Nm4vdzJrd2JyZnlPUHhTaXUvdWdueXFGMG5WeU1ITmlsVGlMcnRiM2lCdlNFQlRUbHladwpLTnM4SkRVVVJ2eHRIQ3F1ZGFrc0Q4YTJ0dUFiNitVUDZUQ28yTW9aZWtUNEdJbmtBanFLODRBTjZMRUtxMEdmCk53SURBUUFCCi0tLS0tRU5EIFJTQSBQVUJMSUMgS0VZLS0tLS0K"}
-2024-03-21T10:19:24.604992Z	ERROR	dkg-initiator	😥 Operator not healthy: 	{"error": "Get \"http://80.181.85.114:3030/health_check\": dial tcp 80.181.85.114:3030: connect: connection refused", "IP": "http://80.181.85.114:3030"}
+2024-03-21T10:19:24.589162Z	INFO	dkg-initiator	🍎 operator online and healthy	{"ID": "416", "IP": "https://141.94.143.182:3030", "Version": "v1.0.3", "Public key": "LS0tLS1CRUdJTiBSU0EgUFVCTElDIEtFWS0tLS0tCk1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBTUlJQkNnS0NBUUVBeHVDaUY2MW5zdTd1MEZhdUZBb1kKWll5ODA0eExENzVuMU0vYjNYTHpaZFpSWUF2aVVyeWJ3Z1gwTEFPRWhPcVIwN0QzTXV3REg0bVhUaXI2Qyt1eQpYaHpVYmFiZXd4V1NDUUtvOFBLSkZWbWxBenh1dHlTb0tPajEvdStnNGgzeHlvMkhsY0M4aERpU3pjdjZXSERtCnhxTjBKcnpHRjU2VmdGMm9EaWsrejBuMmJadDdRMDJWTWVSRnQzamc0dWdzYjY5OEF4aHdFQ3VLYVo4WjZpT3IKT2lIbzdoQUtMaGo5Nm4vdzJrd2JyZnlPUHhTaXUvdWdueXFGMG5WeU1ITmlsVGlMcnRiM2lCdlNFQlRUbHladwpLTnM4SkRVVVJ2eHRIQ3F1ZGFrc0Q4YTJ0dUFiNitVUDZUQ28yTW9aZWtUNEdJbmtBanFLODRBTjZMRUtxMEdmCk53SURBUUFCCi0tLS0tRU5EIFJTQSBQVUJMSUMgS0VZLS0tLS0K"}
+2024-03-21T10:19:24.604992Z	ERROR	dkg-initiator	😥 Operator not healthy: 	{"error": "Get \"https://80.181.85.114:3030/health_check\": dial tcp 80.181.85.114:3030: connect: connection refused", "IP": "https://80.181.85.114:3030"}
 ```
 
 ### Start DKG ceremony
@@ -158,7 +166,7 @@ withdrawAddress: "0xa1a66cc5d309f19fb2fda2b7601b223053d0f7f4" # ETH1 withdrawal 
 owner: "0xb64923DA2c1A9907AdC63617d882D824033a091c" # address of owner of the Cluster that will manage the validator on ssv.network
 nonce: 0 # owner nonce for the SSV contract (default: 0)
 network: "holesky" # network name (default: mainnet)
-operatorsInfo: '[{"id": 1,"public_key": "LS0tLS1CRUdJTiBSU0....","ip": "http://localhost:3030"}, {"id": 2,"public_key": "LS0tLS1CRUdJTiBSU0....","ip": "http://localhost:3030"},...]' # raw content of the JSON file with operators information
+operatorsInfo: '[{"id": 1,"public_key": "LS0tLS1CRUdJTiBSU0....","ip": "https://localhost:3030"}, {"id": 2,"public_key": "LS0tLS1CRUdJTiBSU0....","ip": "https://localhost:3030"},...]' # raw content of the JSON file with operators information
 # Alternatively:
 # operatorsInfoPath: /data/initiator/operators_info.json
 outputPath: /data/output #  path to store the resulting staking deposit and ssv contract payload files
@@ -210,7 +218,7 @@ The Initiator provides the initial details needed to run DKG between all operato
 ssv-dkg init \
           --validators 10
           --operatorIDs 1,2,3,4 \
-          --operatorsInfo: '[{"id": 1,"public_key": "LS0tLS1CRUdJTiBSU0....","ip": "http://localhost:3030"}, {"id": 2,"public_key": "LS0tLS1CRUdJTiBSU0....","ip": "http://localhost:3030"},...]'
+          --operatorsInfo: '[{"id": 1,"public_key": "LS0tLS1CRUdJTiBSU0....","ip": "https://localhost:3030"}, {"id": 2,"public_key": "LS0tLS1CRUdJTiBSU0....","ip": "https://localhost:3030"},...]'
            # Alternatively:
            # --operatorsInfoPath ./operators_info.json \
           --owner 0x81592c3de184a3e2c0dcb5a261bc107bfa91f494 \

--- a/cli/flags/healthcheck.go
+++ b/cli/flags/healthcheck.go
@@ -5,5 +5,7 @@ import (
 )
 
 func SetHealthCheckFlags(cmd *cobra.Command) {
-	AddPersistentStringSliceFlag(cmd, "ip", []string{}, "Operator ip:port", true)
+	AddPersistentStringSliceFlag(cmd, "ip", []string{}, "Operator endpoint(s) to ping (https://host:port). If empty, pings all operators from operatorsInfo", false)
+	OperatorsInfoFlag(cmd)
+	OperatorsInfoPathFlag(cmd)
 }

--- a/cli/initiator/initiator_health_check.go
+++ b/cli/initiator/initiator_health_check.go
@@ -8,6 +8,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/ssvlabs/ssv-dkg/cli/flags"
+	cli_utils "github.com/ssvlabs/ssv-dkg/cli/utils"
 	"github.com/ssvlabs/ssv-dkg/pkgs/initiator"
 )
 
@@ -41,7 +42,40 @@ var HealthCheck = &cobra.Command{
 			ips[i] = strings.TrimRight(s, "/")
 		}
 
-		dkgInitiator, err := initiator.New(nil, logger, cmd.Version, nil, true)
+		operatorsInfo, err := cmd.Flags().GetString("operatorsInfo")
+		if err != nil {
+			return fmt.Errorf("😥 %w", err)
+		}
+		operatorsInfoPath, err := cmd.Flags().GetString("operatorsInfoPath")
+		if err != nil {
+			return fmt.Errorf("😥 %w", err)
+		}
+		if operatorsInfo != "" && operatorsInfoPath != "" {
+			return fmt.Errorf("😥 operators info can be provided either as a raw JSON string, or path to a file, not both")
+		}
+		if operatorsInfo == "" && operatorsInfoPath == "" {
+			return fmt.Errorf("😥 operators info should be provided either as a raw JSON string, or path to a file")
+		}
+
+		opMap, err := cli_utils.LoadOperators(logger, operatorsInfo, operatorsInfoPath)
+		if err != nil {
+			return fmt.Errorf("😥 %w", err)
+		}
+
+		if len(ips) == 0 {
+			ips = make([]string, 0, len(opMap))
+			for _, op := range opMap {
+				ips = append(ips, op.Addr)
+			}
+		} else {
+			for _, ip := range ips {
+				if opMap.ByAddr(ip) == nil {
+					return fmt.Errorf("😥 operator address %s not found in operators list", ip)
+				}
+			}
+		}
+
+		dkgInitiator, err := initiator.New(opMap.Clone(), logger, cmd.Version, nil, true)
 		if err != nil {
 			return fmt.Errorf("😥 %w", err)
 		}

--- a/integration_test/health_check_test.go
+++ b/integration_test/health_check_test.go
@@ -1,6 +1,8 @@
 package integration_test
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/ethereum/go-ethereum"
@@ -9,8 +11,10 @@ import (
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
 
+	spec_crypto "github.com/ssvlabs/dkg-spec/crypto"
 	"github.com/ssvlabs/dkg-spec/testing/stubs"
 	"github.com/ssvlabs/ssv-dkg/pkgs/initiator"
+	"github.com/ssvlabs/ssv-dkg/pkgs/wire"
 )
 
 func TestHealthCheck(t *testing.T) {
@@ -20,7 +24,7 @@ func TestHealthCheck(t *testing.T) {
 			return nil, nil
 		},
 	}
-	servers, _ := createOperators(t, testVersion, stubClient)
+	servers, ops := createOperators(t, testVersion, stubClient)
 	t.Cleanup(func() {
 		for _, srv := range servers {
 			srv.HttpSrv.Close()
@@ -32,7 +36,7 @@ func TestHealthCheck(t *testing.T) {
 	}
 	t.Run("positive", func(t *testing.T) {
 		core, logs := observer.New(zap.DebugLevel)
-		dkgInitiator, err := initiator.New(nil, zap.New(core), testVersion, nil, true)
+		dkgInitiator, err := initiator.New(ops.Clone(), zap.New(core), testVersion, nil, true)
 		require.NoError(t, err)
 		err = dkgInitiator.Ping([]string{ips[0]})
 		require.NoError(t, err)
@@ -42,11 +46,78 @@ func TestHealthCheck(t *testing.T) {
 	t.Run("negative", func(t *testing.T) {
 		servers[0].HttpSrv.Close()
 		core, logs := observer.New(zap.DebugLevel)
-		dkgInitiator, err := initiator.New(nil, zap.New(core), testVersion, nil, true)
+		dkgInitiator, err := initiator.New(ops.Clone(), zap.New(core), testVersion, nil, true)
 		require.NoError(t, err)
 		err = dkgInitiator.Ping([]string{ips[0]})
 		require.NoError(t, err)
 		matches := logs.FilterLevelExact(zapcore.ErrorLevel).FilterMessageSnippet("operator not healthy")
 		require.GreaterOrEqual(t, matches.Len(), 1, "expected unhealthy operator log message")
+	})
+
+	t.Run("spoofed_identity_rejected", func(t *testing.T) {
+		t.Parallel()
+
+		// Operator list contains the *expected* (known) public key for the endpoint.
+		expectedPrivKey, _, err := spec_crypto.GenerateRSAKeys()
+		require.NoError(t, err)
+		attackerPrivKey, _, err := spec_crypto.GenerateRSAKeys()
+		require.NoError(t, err)
+
+		attackerPubBytes, err := spec_crypto.EncodeRSAPublicKey(&attackerPrivKey.PublicKey)
+		require.NoError(t, err)
+
+		const operatorID uint64 = 11
+		pong := &wire.Pong{
+			ID:                 operatorID,
+			PubKey:             attackerPubBytes,
+			Multisig:           true,
+			EthClientConnected: true,
+		}
+		pongData, err := pong.MarshalSSZ()
+		require.NoError(t, err)
+
+		transport := &wire.Transport{
+			Type:       wire.PongMessageType,
+			Identifier: [24]byte{},
+			Data:       pongData,
+			Version:    []byte(testVersion),
+		}
+		transportBytes, err := transport.MarshalSSZ()
+		require.NoError(t, err)
+		sig, err := spec_crypto.SignRSA(attackerPrivKey, transportBytes)
+		require.NoError(t, err)
+
+		signed := &wire.SignedTransport{
+			Message:   transport,
+			Signer:    attackerPubBytes,
+			Signature: sig,
+		}
+		respBytes, err := signed.MarshalSSZ()
+		require.NoError(t, err)
+
+		ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/health_check" {
+				http.NotFound(w, r)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(respBytes)
+		}))
+		t.Cleanup(ts.Close)
+
+		core, logs := observer.New(zap.DebugLevel)
+		dkgInitiator, err := initiator.New(wire.OperatorsCLI{
+			{
+				Addr:   ts.URL,
+				ID:     operatorID,
+				PubKey: &expectedPrivKey.PublicKey,
+			},
+		}, zap.New(core), testVersion, nil, true)
+		require.NoError(t, err)
+
+		err = dkgInitiator.Ping([]string{ts.URL})
+		require.NoError(t, err)
+		matches := logs.FilterLevelExact(zapcore.ErrorLevel).FilterMessageSnippet("operator not healthy")
+		require.GreaterOrEqual(t, matches.Len(), 1, "expected spoofed identity to be rejected")
 	})
 }

--- a/integration_test/health_check_test.go
+++ b/integration_test/health_check_test.go
@@ -1,8 +1,10 @@
 package integration_test
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/ethereum/go-ethereum"
@@ -119,5 +121,82 @@ func TestHealthCheck(t *testing.T) {
 		require.NoError(t, err)
 		matches := logs.FilterLevelExact(zapcore.ErrorLevel).FilterMessageSnippet("operator not healthy")
 		require.GreaterOrEqual(t, matches.Len(), 1, "expected spoofed identity to be rejected")
+	})
+
+	t.Run("operator_id_mismatch_rejected", func(t *testing.T) {
+		t.Parallel()
+
+		expectedPrivKey, _, err := spec_crypto.GenerateRSAKeys()
+		require.NoError(t, err)
+
+		expectedPubBytes, err := spec_crypto.EncodeRSAPublicKey(&expectedPrivKey.PublicKey)
+		require.NoError(t, err)
+
+		const expectedOperatorID uint64 = 11
+		const mismatchedOperatorID uint64 = 22
+		pong := &wire.Pong{
+			ID:                 mismatchedOperatorID,
+			PubKey:             expectedPubBytes,
+			Multisig:           true,
+			EthClientConnected: true,
+		}
+		pongData, err := pong.MarshalSSZ()
+		require.NoError(t, err)
+
+		transport := &wire.Transport{
+			Type:       wire.PongMessageType,
+			Identifier: [24]byte{},
+			Data:       pongData,
+			Version:    []byte(testVersion),
+		}
+		transportBytes, err := transport.MarshalSSZ()
+		require.NoError(t, err)
+		sig, err := spec_crypto.SignRSA(expectedPrivKey, transportBytes)
+		require.NoError(t, err)
+
+		signed := &wire.SignedTransport{
+			Message:   transport,
+			Signer:    expectedPubBytes,
+			Signature: sig,
+		}
+		respBytes, err := signed.MarshalSSZ()
+		require.NoError(t, err)
+
+		ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/health_check" {
+				http.NotFound(w, r)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(respBytes)
+		}))
+		t.Cleanup(ts.Close)
+
+		core, logs := observer.New(zap.DebugLevel)
+		dkgInitiator, err := initiator.New(wire.OperatorsCLI{
+			{
+				Addr:   ts.URL,
+				ID:     expectedOperatorID,
+				PubKey: &expectedPrivKey.PublicKey,
+			},
+		}, zap.New(core), testVersion, nil, true)
+		require.NoError(t, err)
+
+		err = dkgInitiator.Ping([]string{ts.URL})
+		require.NoError(t, err)
+
+		entries := logs.FilterLevelExact(zapcore.ErrorLevel).FilterMessageSnippet("operator not healthy").All()
+		require.NotEmpty(t, entries, "expected unhealthy operator log message")
+
+		var found bool
+		for _, e := range entries {
+			ctx := e.ContextMap()
+			errVal := fmt.Sprint(ctx["error"])
+			if strings.Contains(errVal, "does not match expected operator ID") {
+				found = true
+				break
+			}
+		}
+		require.True(t, found, "expected operator ID mismatch to be rejected")
 	})
 }

--- a/pkgs/initiator/initiator.go
+++ b/pkgs/initiator/initiator.go
@@ -792,15 +792,15 @@ func (c *Initiator) processPongMessage(res wire.PongResult) error {
 	if expectedOperator == nil {
 		return fmt.Errorf("operator address %s not found in operators list", res.IP)
 	}
-		signedPongMsg := &wire.SignedTransport{}
-		if err := signedPongMsg.UnmarshalSSZ(res.Result); err != nil {
-			if strings.Contains(err.Error(), "incorrect offset") {
-				return fmt.Errorf("operator probably of old version, please upgrade: %w", err)
-			}
-			// in case we received error message, try unmarshall
-			errString, parseErr := wire.ParseAsError(res.Result)
-			if parseErr != nil {
-				return fmt.Errorf("cant parse error message: %w", parseErr)
+	signedPongMsg := &wire.SignedTransport{}
+	if err := signedPongMsg.UnmarshalSSZ(res.Result); err != nil {
+		if strings.Contains(err.Error(), "incorrect offset") {
+			return fmt.Errorf("operator probably of old version, please upgrade: %w", err)
+		}
+		// in case we received error message, try unmarshall
+		errString, parseErr := wire.ParseAsError(res.Result)
+		if parseErr != nil {
+			return fmt.Errorf("cant parse error message: %w", parseErr)
 		}
 		return fmt.Errorf("operator returned error: %s", errString)
 	}
@@ -821,14 +821,14 @@ func (c *Initiator) processPongMessage(res wire.PongResult) error {
 		return fmt.Errorf("error marshalling signedPongMsg: %w", err)
 	}
 	// Verify the pong signature using the operator's known RSA public key (from operators list).
-		if err := spec_crypto.VerifyRSA(expectedOperator.PubKey, pongBytes, signedPongMsg.Signature); err != nil {
-			return fmt.Errorf("operator sent pong with invalid signature for operator ID %d: %w", expectedOperator.ID, err)
-		}
-		// Defense-in-depth: verify the pong payload's embedded public key matches the expected key.
-		expectedPubKeyBytes, err := spec_crypto.EncodeRSAPublicKey(expectedOperator.PubKey)
-		if err != nil {
-			return fmt.Errorf("failed to encode expected operator RSA public key for operator ID %d: %w", expectedOperator.ID, err)
-		}
+	if err := spec_crypto.VerifyRSA(expectedOperator.PubKey, pongBytes, signedPongMsg.Signature); err != nil {
+		return fmt.Errorf("operator sent pong with invalid signature for operator ID %d: %w", expectedOperator.ID, err)
+	}
+	// Defense-in-depth: verify the pong payload's embedded public key matches the expected key.
+	expectedPubKeyBytes, err := spec_crypto.EncodeRSAPublicKey(expectedOperator.PubKey)
+	if err != nil {
+		return fmt.Errorf("failed to encode expected operator RSA public key for operator ID %d: %w", expectedOperator.ID, err)
+	}
 	if !bytes.Equal(pong.PubKey, expectedPubKeyBytes) {
 		return fmt.Errorf("operator pong payload public key mismatch for operator ID %d", expectedOperator.ID)
 	}

--- a/pkgs/initiator/initiator.go
+++ b/pkgs/initiator/initiator.go
@@ -785,15 +785,22 @@ func (c *Initiator) processPongMessage(res wire.PongResult) error {
 	if res.Err != nil {
 		return res.Err
 	}
+	if len(c.Operators) == 0 {
+		return fmt.Errorf("operators list is not provided, can't verify pong identity")
+	}
+	expectedOperator := c.Operators.ByAddr(res.IP)
+	if expectedOperator == nil {
+		return fmt.Errorf("operator address %s not found in operators list", res.IP)
+	}
 	signedPongMsg := &wire.SignedTransport{}
 	if err := signedPongMsg.UnmarshalSSZ(res.Result); err != nil {
 		if strings.Contains(err.Error(), "incorrect offset") {
 			return fmt.Errorf("%w, operator probably of old version, please upgrade", err)
 		}
 		// in case we received error message, try unmarshall
-		errString, err := wire.ParseAsError(res.Result)
-		if err == nil {
-			return fmt.Errorf("cant parse error message: %w", err)
+		errString, parseErr := wire.ParseAsError(res.Result)
+		if parseErr != nil {
+			return fmt.Errorf("cant parse error message: %w", parseErr)
 		}
 		return fmt.Errorf("operator returned error: %s", errString)
 	}
@@ -806,17 +813,24 @@ func (c *Initiator) processPongMessage(res wire.PongResult) error {
 		return fmt.Errorf("🆘 cant unmarshall pong message, probably old version, please upgrade: %w", err)
 
 	}
+	if pong.ID != expectedOperator.ID {
+		return fmt.Errorf("operator pong ID %d does not match expected operator ID %d for address %s", pong.ID, expectedOperator.ID, res.IP)
+	}
 	pongBytes, err := signedPongMsg.Message.MarshalSSZ()
 	if err != nil {
 		return fmt.Errorf("error marshalling signedPongMsg: %w", err)
 	}
-	pub, err := spec_crypto.ParseRSAPublicKey(pong.PubKey)
-	if err != nil {
-		return fmt.Errorf("cant parse RSA public key from pong message: %w", err)
+	// Verify the pong signature using the operator's known RSA public key (from operators list).
+	if err := spec_crypto.VerifyRSA(expectedOperator.PubKey, pongBytes, signedPongMsg.Signature); err != nil {
+		return fmt.Errorf("operator sent pong with invalid signature for operator ID %d: %w", expectedOperator.ID, err)
 	}
-	// Check that we got pong with correct pub
-	if err := spec_crypto.VerifyRSA(pub, pongBytes, signedPongMsg.Signature); err != nil {
-		return fmt.Errorf("operator sent pong with wrong RSA public key %w", err)
+	// Optional consistency check: the pong payload should include the expected public key.
+	expectedPubKeyBytes, err := spec_crypto.EncodeRSAPublicKey(expectedOperator.PubKey)
+	if err != nil {
+		return fmt.Errorf("failed to encode expected operator RSA public key for operator ID %d: %w", expectedOperator.ID, err)
+	}
+	if !bytes.Equal(pong.PubKey, expectedPubKeyBytes) {
+		return fmt.Errorf("operator pong payload public key mismatch for operator ID %d", expectedOperator.ID)
 	}
 	if pong.Multisig {
 		if pong.EthClientConnected {

--- a/pkgs/initiator/initiator.go
+++ b/pkgs/initiator/initiator.go
@@ -792,15 +792,15 @@ func (c *Initiator) processPongMessage(res wire.PongResult) error {
 	if expectedOperator == nil {
 		return fmt.Errorf("operator address %s not found in operators list", res.IP)
 	}
-	signedPongMsg := &wire.SignedTransport{}
-	if err := signedPongMsg.UnmarshalSSZ(res.Result); err != nil {
-		if strings.Contains(err.Error(), "incorrect offset") {
-			return fmt.Errorf("%w, operator probably of old version, please upgrade", err)
-		}
-		// in case we received error message, try unmarshall
-		errString, parseErr := wire.ParseAsError(res.Result)
-		if parseErr != nil {
-			return fmt.Errorf("cant parse error message: %w", parseErr)
+		signedPongMsg := &wire.SignedTransport{}
+		if err := signedPongMsg.UnmarshalSSZ(res.Result); err != nil {
+			if strings.Contains(err.Error(), "incorrect offset") {
+				return fmt.Errorf("operator probably of old version, please upgrade: %w", err)
+			}
+			// in case we received error message, try unmarshall
+			errString, parseErr := wire.ParseAsError(res.Result)
+			if parseErr != nil {
+				return fmt.Errorf("cant parse error message: %w", parseErr)
 		}
 		return fmt.Errorf("operator returned error: %s", errString)
 	}
@@ -821,14 +821,14 @@ func (c *Initiator) processPongMessage(res wire.PongResult) error {
 		return fmt.Errorf("error marshalling signedPongMsg: %w", err)
 	}
 	// Verify the pong signature using the operator's known RSA public key (from operators list).
-	if err := spec_crypto.VerifyRSA(expectedOperator.PubKey, pongBytes, signedPongMsg.Signature); err != nil {
-		return fmt.Errorf("operator sent pong with invalid signature for operator ID %d: %w", expectedOperator.ID, err)
-	}
-	// Optional consistency check: the pong payload should include the expected public key.
-	expectedPubKeyBytes, err := spec_crypto.EncodeRSAPublicKey(expectedOperator.PubKey)
-	if err != nil {
-		return fmt.Errorf("failed to encode expected operator RSA public key for operator ID %d: %w", expectedOperator.ID, err)
-	}
+		if err := spec_crypto.VerifyRSA(expectedOperator.PubKey, pongBytes, signedPongMsg.Signature); err != nil {
+			return fmt.Errorf("operator sent pong with invalid signature for operator ID %d: %w", expectedOperator.ID, err)
+		}
+		// Defense-in-depth: verify the pong payload's embedded public key matches the expected key.
+		expectedPubKeyBytes, err := spec_crypto.EncodeRSAPublicKey(expectedOperator.PubKey)
+		if err != nil {
+			return fmt.Errorf("failed to encode expected operator RSA public key for operator ID %d: %w", expectedOperator.ID, err)
+		}
 	if !bytes.Equal(pong.PubKey, expectedPubKeyBytes) {
 		return fmt.Errorf("operator pong payload public key mismatch for operator ID %d", expectedOperator.ID)
 	}

--- a/pkgs/wire/types_json.go
+++ b/pkgs/wire/types_json.go
@@ -164,6 +164,16 @@ func (o OperatorsCLI) ByID(id uint64) *OperatorCLI {
 	return nil
 }
 
+func (o OperatorsCLI) ByAddr(addr string) *OperatorCLI {
+	normalizedAddr := strings.TrimRight(addr, "/")
+	for _, op := range o {
+		if strings.TrimRight(op.Addr, "/") == normalizedAddr {
+			return &op
+		}
+	}
+	return nil
+}
+
 func (o OperatorsCLI) ByPubKey(pk *rsa.PublicKey) *OperatorCLI {
 	encodedPk, err := EncodeRSAPublicKey(pk)
 	if err != nil {


### PR DESCRIPTION
Fix for:

F-ssv-dkg-021 P2 Triaged
Pong Message Self-Verification is Circular
ssv-dkg · Security · Assigned: dev4 · Effort: —

The health check verified the pong signature using a public key extracted from the pong itself. An attacker could generate any key pair, sign a pong, and include the public key — it would always verify.

Impact: operator identity can be spoofed during health checks, misleading the initiator about which operators are online.

Breaking change (CLI):
- `ping` now requires a trusted operator list via `--operatorsInfo` or `--operatorsInfoPath` to verify operator identity.
- `--ip` is optional; if omitted, `ping` pings all operators from the provided operators list.