### PR TITLE
ci: add Docker Hub release workflow with ARM64 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: "1.25.8"
+  GO_VERSION: "1.25.9"
   CGO_ENABLED: "1"
 
 jobs:

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,0 +1,46 @@
+name: Docker Release
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.*"
+
+concurrency:
+  group: docker-release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  docker:
+    name: Build and push multi-arch Docker image
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - uses: docker/setup-qemu-action@v4.0.0
+        with:
+          platforms: linux/arm64
+
+      - uses: docker/setup-buildx-action@v4.0.0
+
+      - uses: docker/login-action@v4.1.0
+        with:
+          username: ssvlabs
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v7.0.0
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ssvlabs/ssv-dkg:${{ github.ref_name }}
+            ssvlabs/ssv-dkg:latest
+          build-args: |
+            VERSION=${{ github.ref_name }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: docker/login-action@v4.1.0
         with:
           username: ssvlabs
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          password: ${{ secrets.SSV_DKG_DOCKERHUB_TOKEN }}
 
       - name: Build and push
         uses: docker/build-push-action@v7.0.0

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  GO_VERSION: "1.25.8"
+  GO_VERSION: "1.25.9"
 
 jobs:
   release:

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     ./cmd/ssv-dkg
 
 # Final stage
-FROM alpine:3.21@sha256:22e0ec13c0db6b3e1ba3280e831fc50ba7bffe58e81f31670a64b1afede247bc
+FROM alpine:3.21@sha256:c3f8e73fdb79deaebaa2037150150191b9dcbfba68b4a46d70103204c53f4709
 WORKDIR /ssv-dkg
 
 LABEL org.opencontainers.image.title="SSV DKG" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.8-alpine@sha256:8e02eb337d9e0ea459e041f1ee5eece41cbb61f1d83e7d883a3e2fb4862063fa AS build
+FROM golang:1.25.9-alpine@sha256:7a00384194cf2cb68924bbb918d675f1517357433c8541bac0ab2f929b9d5447 AS build
 
 ARG VERSION=dev
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ssvlabs/ssv-dkg
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/aquasecurity/table v1.11.0


### PR DESCRIPTION
## Summary
- Add `.github/workflows/docker-release.yml` — builds and pushes multi-arch (amd64 + arm64) Docker images to Docker Hub on `v*` tag push
- Fix `Dockerfile` alpine base image SHA pin from amd64-only platform digest to manifest list digest, enabling ARM64 builds

## Context
Supersedes the Docker Hub workflow portion of #218. The remaining changes in #218 (Makefile, README, GitLab CI) can be evaluated separately.

## Finding
F-ssv-dkg-034: Docker Hub CI missing — no docker image published on tag

## Test
- Verified golang base image SHA is already a manifest list (multi-arch safe)
- Verified alpine SHA was amd64-only; replaced with manifest list digest
- Full validation requires a test tag push

---

**UPDATE:** Bumped Go 1.25.8 → 1.25.9 across `ci.yml`, `releases.yml`, `Dockerfile`, and `go.mod` to resolve 3 stdlib CVEs flagged by `govulncheck` (GO-2026-4947, GO-2026-4946, GO-2026-4870 — `crypto/x509` and `crypto/tls`).