### PR TITLE
Load multisig RPC configuration from environment - F-ssv-dkg-009

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,8 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: Run integration tests
+        env:
+          ETH_RPC_URL: ${{ secrets.ETH_RPC_URL }}
         run: make test-integration
 
   lint:

--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,6 @@ dkg_output*/
 examples/*/output/*
 
 # Secrets
-.env
 *.env
 
 # Node.js (for utils/ JS helpers)

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ examples/*/output/*
 
 # Secrets
 .env
+*.env
 
 # Node.js (for utils/ JS helpers)
 node_modules/

--- a/integration_test/multisig_test.go
+++ b/integration_test/multisig_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/accounts/keystore"
@@ -18,7 +19,23 @@ import (
 	"github.com/ssvlabs/ssv-dkg/pkgs/wire"
 )
 
-const EthRPC string = "https://eth-sepolia.g.alchemy.com/v2/YyqRIEgydRXKTTT-w_0jtKSAH6sfr8qz"
+const ethRPCEnvVar = "ETH_RPC_URL"
+
+// requireEthereumClient skips RPC-dependent tests when no endpoint is configured locally.
+func requireEthereumClient(t *testing.T) *ethclient.Client {
+	t.Helper()
+
+	ethRPC := strings.TrimSpace(os.Getenv(ethRPCEnvVar))
+	if ethRPC == "" {
+		t.Skipf("%s is not set", ethRPCEnvVar)
+	}
+
+	client, err := ethclient.Dial(ethRPC)
+	require.NoError(t, err)
+	t.Cleanup(client.Close)
+
+	return client
+}
 
 func TestReshareBulkJSONPArsing(t *testing.T) {
 	t.Parallel()
@@ -73,8 +90,7 @@ func TestVerifyMultisigSignedOnChain2of3(t *testing.T) {
 	t.Parallel()
 	t.Run("valid Gnosis 3/3 miltisig signatures", func(t *testing.T) {
 		gnosisAddress := common.HexToAddress("0x0205c708899bde67330456886a05Fe30De0A79b6")
-		ethBackend, err := ethclient.Dial(EthRPC)
-		require.NoError(t, err)
+		ethBackend := requireEthereumClient(t)
 
 		var finalMsg []byte
 		message := []byte("I am the owner of this Safe account")
@@ -102,8 +118,7 @@ func TestVerifyMultisigSignedOnChain(t *testing.T) {
 	t.Parallel()
 	t.Run("valid Gnosis 3/3 miltisig signatures", func(t *testing.T) {
 		gnosisAddress := common.HexToAddress("0x0205c708899bde67330456886a05Fe30De0A79b6")
-		ethBackend, err := ethclient.Dial(EthRPC)
-		require.NoError(t, err)
+		ethBackend := requireEthereumClient(t)
 
 		var finalMsg []byte
 		message := []byte("I am the owner of this Safe account")
@@ -118,7 +133,6 @@ func TestVerifyMultisigSignedOnChain(t *testing.T) {
 		copy(hash[:], keccak256)
 		t.Log("Hash", hex.EncodeToString(hash[:]))
 
-		require.NoError(t, err)
 		require.NoError(t, spec_crypto.VerifySignedMessageByOwner(ethBackend,
 			gnosisAddress,
 			hash,
@@ -130,8 +144,7 @@ func TestVerifyMultisigSignedOffChain(t *testing.T) {
 	t.Parallel()
 	t.Run("valid Gnosis 2/3 miltisig offchain signatures", func(t *testing.T) {
 		gnosisAddress := common.HexToAddress("0x43908b5794da9A8f714f001567D8dA1523e68bDb")
-		ethBackend, err := ethclient.Dial(EthRPC)
-		require.NoError(t, err)
+		ethBackend := requireEthereumClient(t)
 
 		msg := "932ab87aee23606dd0c085cab46322ffed345a3aa028673c25f72b5d486e14e2"
 
@@ -159,8 +172,7 @@ func TestVerifyEOASigned(t *testing.T) {
 	t.Parallel()
 	t.Run("valid EOA signatures", func(t *testing.T) {
 		gnosisAddress := common.HexToAddress("0xDCc846fA10C7CfCE9e6Eb37e06eD93b666cFC5E9")
-		ethBackend, err := ethclient.Dial(EthRPC)
-		require.NoError(t, err)
+		ethBackend := requireEthereumClient(t)
 
 		msg := "a3703ef95414e008f95e9d0adb6e0122e70ea2a71459eeafe3382dd24ae03706"
 

--- a/integration_test/multisig_test.go
+++ b/integration_test/multisig_test.go
@@ -21,12 +21,15 @@ import (
 
 const ethRPCEnvVar = "ETH_RPC_URL"
 
-// requireEthereumClient skips RPC-dependent tests when no endpoint is configured locally.
+// requireEthereumClient skips RPC-dependent tests locally, but keeps CI coverage visible.
 func requireEthereumClient(t *testing.T) *ethclient.Client {
 	t.Helper()
 
 	ethRPC := strings.TrimSpace(os.Getenv(ethRPCEnvVar))
 	if ethRPC == "" {
+		if os.Getenv("CI") == "true" {
+			t.Fatalf("%s must be set in CI to run multisig integration tests", ethRPCEnvVar)
+		}
 		t.Skipf("%s is not set", ethRPCEnvVar)
 	}
 

--- a/utils/gnosis_multisig_examples/safe_off_chain/README.md
+++ b/utils/gnosis_multisig_examples/safe_off_chain/README.md
@@ -5,12 +5,18 @@
 Use Safe wallet https://app.safe.global/:
 
 1. create a new Safe wallet with 3 accounts and 2 threshold
-2. Use private keys at script to sign message
+2. Load the RPC URL and owner private keys from environment variables instead of editing the script:
 
 ```
+$ export ETH_RPC_URL=https://eth-sepolia.g.alchemy.com/v2/<your-key>
+$ export OWNER1_PRIVATE_KEY=<owner-1-private-key>
+$ export OWNER2_PRIVATE_KEY=<owner-2-private-key>
+$ export OWNER3_PRIVATE_KEY=<owner-3-private-key>
 $ yarn install
 $ npx tsc
 $ node index.js
 ```
+
+You can also keep those values in a local `*.env` file and source it before running the script.
 
 3. Go to Safe wallet and confirm the transaction

--- a/utils/gnosis_multisig_examples/safe_off_chain/README.md
+++ b/utils/gnosis_multisig_examples/safe_off_chain/README.md
@@ -19,4 +19,10 @@ $ node index.js
 
 You can also keep those values in a local `*.env` file and source it before running the script.
 
+```
+$ set -a
+$ source local.env
+$ set +a
+```
+
 3. Go to Safe wallet and confirm the transaction

--- a/utils/gnosis_multisig_examples/safe_off_chain/index.ts
+++ b/utils/gnosis_multisig_examples/safe_off_chain/index.ts
@@ -14,6 +14,15 @@ import SafeApiKit, {
 // This file can be used to play around with the Safe Core SDK
 import fs from "fs";
 
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} must be set`);
+  }
+
+  return value;
+}
+
 interface Config {
   RPC_URL: string;
   OWNER1_PRIVATE_KEY: string;
@@ -30,14 +39,10 @@ interface Config {
 //   - Owner 3: public address from OWNER3_PRIVATE_KEY
 //   - SAFE_WALLET: public of safe wallet address with 2/3 threshold
 const config: Config = {
-  RPC_URL:
-    "https://eth-sepolia.g.alchemy.com/v2/YyqRIEgydRXKTTT-w_0jtKSAH6sfr8qz",
-  OWNER1_PRIVATE_KEY:
-    "",
-  OWNER2_PRIVATE_KEY:
-    "",
-  OWNER3_PRIVATE_KEY:
-    "",
+  RPC_URL: requireEnv("ETH_RPC_URL"),
+  OWNER1_PRIVATE_KEY: requireEnv("OWNER1_PRIVATE_KEY"),
+  OWNER2_PRIVATE_KEY: requireEnv("OWNER2_PRIVATE_KEY"),
+  OWNER3_PRIVATE_KEY: requireEnv("OWNER3_PRIVATE_KEY"),
   SAFE_ADDRESS: "0x43908b5794da9A8f714f001567D8dA1523e68bDb",
   CHAIN_ID: 11155111n,
 };

--- a/utils/gnosis_multisig_examples/safe_on_chain/README.md
+++ b/utils/gnosis_multisig_examples/safe_on_chain/README.md
@@ -5,12 +5,18 @@
 Use Safe wallet https://app.safe.global/:
 
 1. create a new Safe wallet with 3 accounts and 2 threshold
-2. Use private keys at script to sign message
+2. Load the RPC URL and owner private keys from environment variables instead of editing the script:
 
 ```
+$ export ETH_RPC_URL=https://eth-sepolia.g.alchemy.com/v2/<your-key>
+$ export OWNER1_PRIVATE_KEY=<owner-1-private-key>
+$ export OWNER2_PRIVATE_KEY=<owner-2-private-key>
+$ export OWNER3_PRIVATE_KEY=<owner-3-private-key>
 $ yarn install
 $ npx tsc
 $ node index.js
 ```
+
+You can also keep those values in a local `*.env` file and source it before running the script.
 
 3. Go to Safe wallet and confirm the transaction

--- a/utils/gnosis_multisig_examples/safe_on_chain/README.md
+++ b/utils/gnosis_multisig_examples/safe_on_chain/README.md
@@ -19,4 +19,10 @@ $ node index.js
 
 You can also keep those values in a local `*.env` file and source it before running the script.
 
+```
+$ set -a
+$ source local.env
+$ set +a
+```
+
 3. Go to Safe wallet and confirm the transaction

--- a/utils/gnosis_multisig_examples/safe_on_chain/index.ts
+++ b/utils/gnosis_multisig_examples/safe_on_chain/index.ts
@@ -11,6 +11,15 @@ import {
 import SafeApiKit from "@safe-global/api-kit";
 // This file can be used to play around with the Safe Core SDK
 
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} must be set`);
+  }
+
+  return value;
+}
+
 interface Config {
   RPC_URL: string;
   OWNER1_PRIVATE_KEY: string;
@@ -27,14 +36,10 @@ interface Config {
 //   - Owner 3: public address from OWNER3_PRIVATE_KEY
 //   - SAFE_WALLET: public of safe wallet address with 2/3 threshold
 const config: Config = {
-  RPC_URL:
-    "https://eth-sepolia.g.alchemy.com/v2/YyqRIEgydRXKTTT-w_0jtKSAH6sfr8qz",
-  OWNER1_PRIVATE_KEY:
-    "",
-  OWNER2_PRIVATE_KEY:
-    "",
-  OWNER3_PRIVATE_KEY:
-    "",
+  RPC_URL: requireEnv("ETH_RPC_URL"),
+  OWNER1_PRIVATE_KEY: requireEnv("OWNER1_PRIVATE_KEY"),
+  OWNER2_PRIVATE_KEY: requireEnv("OWNER2_PRIVATE_KEY"),
+  OWNER3_PRIVATE_KEY: requireEnv("OWNER3_PRIVATE_KEY"),
   SAFE_ADDRESS: "0x0205c708899bde67330456886a05Fe30De0A79b6",
   CHAIN_ID: 11155111n,
 };

--- a/utils/gnosis_multisig_examples/safe_on_chain_2/README.md
+++ b/utils/gnosis_multisig_examples/safe_on_chain_2/README.md
@@ -5,10 +5,16 @@
 Use Safe wallet https://app.safe.global/:
 
 1. create a new Safe wallet with 3 accounts and 2 threshold
-2. Use private keys at script to sign hash of the reshare JSON
+2. Load the RPC URL and owner private keys from environment variables instead of editing the script:
 
 ```
+$ export ETH_RPC_URL=https://eth-sepolia.g.alchemy.com/v2/<your-key>
+$ export OWNER1_PRIVATE_KEY=<owner-1-private-key>
+$ export OWNER2_PRIVATE_KEY=<owner-2-private-key>
+$ export OWNER3_PRIVATE_KEY=<owner-3-private-key>
 $ yarn install
 $ npx tsc
 $ node index.js
 ```
+
+You can also keep those values in a local `*.env` file and source it before running the script.

--- a/utils/gnosis_multisig_examples/safe_on_chain_2/README.md
+++ b/utils/gnosis_multisig_examples/safe_on_chain_2/README.md
@@ -18,3 +18,9 @@ $ node index.js
 ```
 
 You can also keep those values in a local `*.env` file and source it before running the script.
+
+```
+$ set -a
+$ source local.env
+$ set +a
+```

--- a/utils/gnosis_multisig_examples/safe_on_chain_2/index.ts
+++ b/utils/gnosis_multisig_examples/safe_on_chain_2/index.ts
@@ -3,6 +3,15 @@ import { hashSafeMessage } from '@safe-global/protocol-kit'
 
 // This file can be used to play around with the Safe Core SDK
 
+function requireEnv(name: string): string {
+  const value = process.env[name]
+  if (!value) {
+    throw new Error(`${name} must be set`)
+  }
+
+  return value
+}
+
 interface Config {
   RPC_URL: string
   OWNER1_PRIVATE_KEY: string
@@ -18,10 +27,10 @@ interface Config {
 //   - Owner 3: public address from OWNER3_PRIVATE_KEY
 //   - SAFE_WALLET: public of safe wallet address with 2/3 threshold
 const config: Config = {
-  RPC_URL: 'https://eth-sepolia.g.alchemy.com/v2/YyqRIEgydRXKTTT-w_0jtKSAH6sfr8qz',
-  OWNER1_PRIVATE_KEY: '',
-  OWNER2_PRIVATE_KEY: '',
-  OWNER3_PRIVATE_KEY: '',
+  RPC_URL: requireEnv('ETH_RPC_URL'),
+  OWNER1_PRIVATE_KEY: requireEnv('OWNER1_PRIVATE_KEY'),
+  OWNER2_PRIVATE_KEY: requireEnv('OWNER2_PRIVATE_KEY'),
+  OWNER3_PRIVATE_KEY: requireEnv('OWNER3_PRIVATE_KEY'),
   SAFE_3_3_ADDRESS: '0x0205c708899bde67330456886a05Fe30De0A79b6'
 }
 

--- a/utils/gnosis_multisig_examples/validate/index.ts
+++ b/utils/gnosis_multisig_examples/validate/index.ts
@@ -14,6 +14,15 @@ import SafeApiKit, {
 // This file can be used to play around with the Safe Core SDK
 import fs from "fs";
 
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} must be set`);
+  }
+
+  return value;
+}
+
 interface Config {
   RPC_URL: string;
   OWNER1_PRIVATE_KEY: string;
@@ -30,8 +39,7 @@ interface Config {
 //   - Owner 3: public address from OWNER3_PRIVATE_KEY
 //   - SAFE_WALLET: public of safe wallet address with 2/3 threshold
 const config: Config = {
-  RPC_URL:
-    "https://eth-sepolia.g.alchemy.com/v2/YyqRIEgydRXKTTT-w_0jtKSAH6sfr8qz",
+  RPC_URL: requireEnv("ETH_RPC_URL"),
   OWNER1_PRIVATE_KEY: "",
   OWNER2_PRIVATE_KEY: "",
   OWNER3_PRIVATE_KEY: "",

--- a/utils/gnosis_multisig_examples/validate/index.ts
+++ b/utils/gnosis_multisig_examples/validate/index.ts
@@ -1,16 +1,5 @@
-import Safe, {
-  SigningMethod,
-  buildContractSignature,
-  getSignMessageLibContract,
-} from "@safe-global/protocol-kit";
+import Safe from "@safe-global/protocol-kit";
 import { hashSafeMessage } from "@safe-global/protocol-kit";
-import {
-  OperationType,
-  SafeTransactionDataPartial,
-} from "@safe-global/safe-core-sdk-types";
-import SafeApiKit, {
-  EIP712TypedData as ApiKitEIP712TypedData,
-} from "@safe-global/api-kit";
 // This file can be used to play around with the Safe Core SDK
 import fs from "fs";
 
@@ -25,34 +14,15 @@ function requireEnv(name: string): string {
 
 interface Config {
   RPC_URL: string;
-  OWNER1_PRIVATE_KEY: string;
-  OWNER2_PRIVATE_KEY: string;
-  OWNER3_PRIVATE_KEY: string;
   SAFE_ADDRESS: string;
-  CHAIN_ID: bigint;
 }
 
-// To run this script, you need a Safe with the following configuration
-// - 3/3 Safe with 3 owners and threshold 3
-//   - Owner 1: public address from OWNER1_PRIVATE_KEY
-//   - Owner 2: public address from OWNER2_PRIVATE_KEY
-//   - Owner 3: public address from OWNER3_PRIVATE_KEY
-//   - SAFE_WALLET: public of safe wallet address with 2/3 threshold
 const config: Config = {
   RPC_URL: requireEnv("ETH_RPC_URL"),
-  OWNER1_PRIVATE_KEY: "",
-  OWNER2_PRIVATE_KEY: "",
-  OWNER3_PRIVATE_KEY: "",
   SAFE_ADDRESS: "0xC4D860871fb983d17eC665a305e98F1B3035a817",
-  CHAIN_ID: 11155111n,
 };
 
 async function main() {
-  // Create Safe API Kit instance
-  const apiKit = new SafeApiKit({
-    chainId: config.CHAIN_ID,
-  });
-
   let protocolKit1 = await Safe.init({
     provider: config.RPC_URL,
     safeAddress: config.SAFE_ADDRESS,
@@ -74,7 +44,6 @@ async function main() {
   );
 
   var MESSAGE = JSON.stringify(reshareBulk);
-  var safeMessage = protocolKit1.createMessage(MESSAGE);
   var messageHash = hashSafeMessage(MESSAGE);
 
   var isValid = await protocolKit1.isValidSignature(
@@ -86,7 +55,6 @@ async function main() {
   console.log("Message Hash: ", messageHash);
   console.log(`The signature is ${isValid ? "valid" : "invalid"}`);
 
-
   var resignBulk = JSON.parse(
     fs.readFileSync(
       "../../../integration_test/stubs/resign/resign_msgs.json",
@@ -95,7 +63,6 @@ async function main() {
   );
 
   MESSAGE = JSON.stringify(resignBulk);
-  safeMessage = protocolKit1.createMessage(MESSAGE);
   messageHash = hashSafeMessage(MESSAGE);
 
   isValid = await protocolKit1.isValidSignature(


### PR DESCRIPTION
## Ticket

`F-ssv-dkg-009`

This fixes a security finding in `ssv-dkg` where an Alchemy Sepolia API key was hardcoded in `integration_test/multisig_test.go` and the Gnosis multisig example scripts under `utils/gnosis_multisig_examples`.

## Changes

- Replaced the hardcoded Ethereum RPC URL in the multisig integration tests with `ETH_RPC_URL` and skip the RPC-dependent tests when it is not set.
- Replaced the hardcoded RPC URL in the Gnosis multisig example scripts with runtime environment variable loading.
- Updated the example READMEs to document the env-based secret flow.
- Expanded `.gitignore` to ignore `*.env` files.

## Validation

- `GOPROXY=https://proxy.golang.org,direct go test -timeout=3600s ./integration_test/... -run 'Test(ReshareBulkJSONPArsing|ResignBulkJSONPArsing|VerifyMultisigSignedOnChain2of3|VerifyMultisigSignedOnChain|VerifyMultisigSignedOffChain|VerifyEOASigned)$'`
- `GOPROXY=https://proxy.golang.org,direct go tool golangci-lint run -v ./integration_test/...`

Fixes - Fixes ssvlabs/ssv-node-board#623
