### PR TITLE
fix: DKG goroutine and instance lifecycle (v3.1.0)

### DIFF
--- a/cli/operator/operator.go
+++ b/cli/operator/operator.go
@@ -1,8 +1,13 @@
 package operator
 
 import (
+	"context"
 	"fmt"
 	"log"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
 
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
@@ -11,6 +16,10 @@ import (
 	cli_utils "github.com/ssvlabs/ssv-dkg/cli/utils"
 	"github.com/ssvlabs/ssv-dkg/pkgs/operator"
 )
+
+// shutdownTimeout bounds how long Stop will wait for in-flight HTTP handlers
+// to drain on SIGTERM/SIGINT before we force the process down.
+const shutdownTimeout = 30 * time.Second
 
 func init() {
 	flags.SetOperatorFlags(StartDKGOperator)
@@ -52,6 +61,20 @@ var StartDKGOperator = &cobra.Command{
 		if err != nil {
 			logger.Fatal("😥 Failed to create new operator instance: ", zap.Error(err))
 		}
+
+		sigs := make(chan os.Signal, 1)
+		signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+		defer signal.Stop(sigs)
+		go func() {
+			sig := <-sigs
+			logger.Info("shutdown signal received, stopping operator", zap.String("signal", sig.String()))
+			ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+			defer cancel()
+			if err := srv.Stop(ctx); err != nil {
+				logger.Error("operator shutdown error", zap.Error(err))
+			}
+		}()
+
 		logger.Info("🚀 Starting DKG operator", zap.Uint64("at port", flags.Port))
 		if err := srv.Start(uint16(flags.Port), flags.ServerTLSCertPath, flags.ServerTLSKeyPath); err != nil {
 			log.Fatalf("Error in operator %v", err)

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/wealdtech/go-eth2-util v1.8.2
 	github.com/wealdtech/go-eth2-wallet-encryptor-keystorev4 v1.4.1
+	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.1
 )
 

--- a/pkgs/dkg/drand.go
+++ b/pkgs/dkg/drand.go
@@ -2,9 +2,11 @@ package dkg
 
 import (
 	"bytes"
+	"context"
 	"crypto/rsa"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
@@ -26,7 +28,15 @@ import (
 	"github.com/ssvlabs/ssv-dkg/pkgs/wire"
 )
 
-const kyberMessageStartWaitTimeout = 2 * time.Second
+const (
+	kyberMessageStartWaitTimeout = 2 * time.Second
+
+	// waitEndCancelGrace bounds how long runWaitEnd waits for a result after
+	// ctx cancellation. Generous enough that a loaded or -race-slowed kyber
+	// still delivers a legitimate completion before we give up, bounded so a
+	// pathological kyber hang can't block cleanup forever.
+	waitEndCancelGrace = 5 * time.Second
+)
 
 // DKGdata structure to store at LocalOwner information about initial message parameters and secret scalar to be used as input for DKG protocol
 type DKGdata struct {
@@ -54,6 +64,9 @@ type OwnerOpts struct {
 	Owner              [20]byte
 	Nonce              uint64
 	Version            []byte
+	// Ctx cancels background goroutines when the owning instance is cleaned up.
+	// Must be non-nil.
+	Ctx context.Context
 }
 
 var ErrAlreadyExists = errors.New("duplicate message")
@@ -76,10 +89,13 @@ type LocalOwner struct {
 	InitiatorPublicKey *rsa.PublicKey
 	OperatorSecretKey  *rsa.PrivateKey
 	done               chan struct{}
+	doneOnce           sync.Once
+	ctx                context.Context
 	version            []byte
 }
 
 // New creates a LocalOwner structure. We create it for each new DKG ceremony.
+// opts.Ctx must be non-nil.
 func New(opts *OwnerOpts) *LocalOwner {
 	owner := &LocalOwner{
 		Logger:             opts.Logger,
@@ -94,10 +110,51 @@ func New(opts *OwnerOpts) *LocalOwner {
 		InitiatorPublicKey: opts.InitiatorPublicKey,
 		OperatorSecretKey:  opts.OperatorSecretKey,
 		done:               make(chan struct{}, 1),
+		ctx:                opts.Ctx,
 		Suite:              opts.Suite,
 		version:            opts.Version,
 	}
 	return owner
+}
+
+func (o *LocalOwner) closeDone() {
+	o.doneOnce.Do(func() { close(o.done) })
+}
+
+// Ctx returns the lifecycle context used by background goroutines.
+func (o *LocalOwner) Ctx() context.Context {
+	return o.ctx
+}
+
+// runWaitEnd waits for the protocol's final result and dispatches it to postF.
+// A ready WaitEnd result wins over ctx cancellation to avoid dropping a
+// completed ceremony when both fire simultaneously.
+func (o *LocalOwner) runWaitEnd(
+	p *kyber_dkg.Protocol,
+	postF func(*kyber_dkg.OptionResult) error,
+	errLabel, cancelLabel string,
+) {
+	dispatch := func(res kyber_dkg.OptionResult) {
+		if err := postF(&res); err != nil {
+			o.Logger.Error(errLabel, zap.Error(err))
+			o.broadcastError(fmt.Errorf("operator ID:%d, err:%w", o.ID, err))
+		}
+	}
+	select {
+	case res := <-p.WaitEnd():
+		dispatch(res)
+	case <-o.ctx.Done():
+		// A non-blocking check would miss results kyber produces a few ms
+		// after cancel while finishing the last phase transition.
+		grace := time.NewTimer(waitEndCancelGrace)
+		defer grace.Stop()
+		select {
+		case res := <-p.WaitEnd():
+			dispatch(res)
+		case <-grace.C:
+			o.Logger.Debug(cancelLabel, zap.Error(o.ctx.Err()))
+		}
+	}
 }
 
 // StartDKG initializes and starts DKG protocol
@@ -127,18 +184,12 @@ func (o *LocalOwner) StartDKG() error {
 		Threshold: int(o.data.init.T), //nolint:gosec // threshold is always small
 		Auth:      drand_bls.NewSchemeOnG2(o.Suite),
 	}
-	p, err := wire.NewDKGProtocol(dkgConfig, o.board, logger)
+	p, err := wire.NewDKGProtocol(o.ctx, dkgConfig, o.board, logger)
 	if err != nil {
 		return err
 	}
 	// Wait when the protocol exchanges finish and process the result
-	go func(p *kyber_dkg.Protocol, postF func(res *kyber_dkg.OptionResult) error) {
-		res := <-p.WaitEnd()
-		if err := postF(&res); err != nil {
-			o.Logger.Error("Error in PostDKG function", zap.Error(err))
-			o.broadcastError(fmt.Errorf("operator ID:%d, err:%w", o.ID, err))
-		}
-	}(p, o.PostDKG)
+	go o.runWaitEnd(p, o.PostDKG, "Error in PostDKG function", "DKG WaitEnd watcher cancelled")
 	close(o.startedDKG)
 	return nil
 }
@@ -217,7 +268,7 @@ func (o *LocalOwner) PostDKG(res *kyber_dkg.OptionResult) error {
 	if err := o.Broadcast(tsMsg); err != nil {
 		return fmt.Errorf("failed to broadcast output in PostDKG: %w", err)
 	}
-	close(o.done)
+	o.closeDone()
 	return nil
 }
 
@@ -259,9 +310,7 @@ func (o *LocalOwner) PostReshare(res *kyber_dkg.OptionResult) error {
 	if err := o.Broadcast(tsMsg); err != nil {
 		return fmt.Errorf("failed to broadcast output in PostReshare: %w", err)
 	}
-	if _, ok := <-o.done; ok {
-		close(o.done)
-	}
+	o.closeDone()
 	return nil
 }
 
@@ -553,7 +602,7 @@ func (o *LocalOwner) broadcastError(err error) {
 	if err := o.Broadcast(errMsg); err != nil {
 		o.Logger.Error("failed to broadcast error message", zap.Error(err))
 	}
-	close(o.done)
+	o.closeDone()
 }
 
 // checkOperators checks that operator received all participating parties DKG public keys
@@ -720,17 +769,11 @@ func (o *LocalOwner) StartReshareDKGOldNodes() error {
 		Auth:         drand_bls.NewSchemeOnG2(o.Suite),
 		Share:        o.SecretShare,
 	}
-	p, err := wire.NewDKGProtocol(dkgConfig, o.board, logger)
+	p, err := wire.NewDKGProtocol(o.ctx, dkgConfig, o.board, logger)
 	if err != nil {
 		return err
 	}
-	go func(p *kyber_dkg.Protocol, postF func(res *kyber_dkg.OptionResult) error) {
-		res := <-p.WaitEnd()
-		if err := postF(&res); err != nil {
-			o.Logger.Error("Error in PostReshare function", zap.Error(err))
-			o.broadcastError(fmt.Errorf("operator ID:%d, err:%w", o.ID, err))
-		}
-	}(p, o.PostReshare)
+	go o.runWaitEnd(p, o.PostReshare, "Error in PostReshare function", "Reshare (old nodes) WaitEnd watcher cancelled")
 	close(o.startedDKG)
 	return nil
 }
@@ -794,7 +837,7 @@ func (o *LocalOwner) StartReshareDKGNewNodes() error {
 		Auth:         drand_bls.NewSchemeOnG2(o.Suite),
 		PublicCoeffs: coefs,
 	}
-	p, err := wire.NewDKGProtocol(dkgConfig, o.board, logger)
+	p, err := wire.NewDKGProtocol(o.ctx, dkgConfig, o.board, logger)
 	if err != nil {
 		return err
 	}
@@ -804,13 +847,7 @@ func (o *LocalOwner) StartReshareDKGNewNodes() error {
 			return fmt.Errorf("failed to enqueue stored deal bundle: %w", err)
 		}
 	}
-	go func(p *kyber_dkg.Protocol, postF func(res *kyber_dkg.OptionResult) error) {
-		res := <-p.WaitEnd()
-		if err := postF(&res); err != nil {
-			o.Logger.Error("Error in PostReshare function", zap.Error(err))
-			o.broadcastError(fmt.Errorf("operator ID:%d, err:%w", o.ID, err))
-		}
-	}(p, o.PostReshare)
+	go o.runWaitEnd(p, o.PostReshare, "Error in PostReshare function", "Reshare (new nodes) WaitEnd watcher cancelled")
 	close(o.startedDKG)
 	return nil
 }

--- a/pkgs/dkg/drand.go
+++ b/pkgs/dkg/drand.go
@@ -50,7 +50,9 @@ type DKGdata struct {
 	secret kyber.Scalar
 }
 
-// OwnerOpts structure to pass parameters from Switch to LocalOwner structure
+// OwnerOpts structure to pass parameters from Switch to LocalOwner structure.
+// The lifecycle context is passed as a positional argument to New; not embedded
+// here so the compiler enforces that callers supply one.
 type OwnerOpts struct {
 	Logger             *zap.Logger
 	ID                 uint64
@@ -64,9 +66,6 @@ type OwnerOpts struct {
 	Owner              [20]byte
 	Nonce              uint64
 	Version            []byte
-	// Ctx cancels background goroutines when the owning instance is cleaned up.
-	// Must be non-nil.
-	Ctx context.Context
 }
 
 var ErrAlreadyExists = errors.New("duplicate message")
@@ -75,6 +74,7 @@ var ErrAlreadyExists = errors.New("duplicate message")
 type LocalOwner struct {
 	Logger             *zap.Logger
 	startedDKG         chan struct{}
+	startedDKGOnce     sync.Once
 	ID                 uint64
 	data               *DKGdata
 	board              *board.Board
@@ -94,9 +94,10 @@ type LocalOwner struct {
 	version            []byte
 }
 
-// New creates a LocalOwner structure. We create it for each new DKG ceremony.
-// opts.Ctx must be non-nil.
-func New(opts *OwnerOpts) *LocalOwner {
+// New creates a LocalOwner structure for a new DKG ceremony. ctx cancels the
+// owner's background goroutines (runWaitEnd, board, kyber protocol) when the
+// owning instance is cleaned up or its deadline fires.
+func New(ctx context.Context, opts *OwnerOpts) *LocalOwner {
 	owner := &LocalOwner{
 		Logger:             opts.Logger,
 		startedDKG:         make(chan struct{}, 1),
@@ -110,7 +111,7 @@ func New(opts *OwnerOpts) *LocalOwner {
 		InitiatorPublicKey: opts.InitiatorPublicKey,
 		OperatorSecretKey:  opts.OperatorSecretKey,
 		done:               make(chan struct{}, 1),
-		ctx:                opts.Ctx,
+		ctx:                ctx,
 		Suite:              opts.Suite,
 		version:            opts.Version,
 	}
@@ -119,6 +120,12 @@ func New(opts *OwnerOpts) *LocalOwner {
 
 func (o *LocalOwner) closeDone() {
 	o.doneOnce.Do(func() { close(o.done) })
+}
+
+// closeStartedDKG closes startedDKG idempotently so concurrent Process paths
+// (same instance, racing on exchanges) can't double-close and panic.
+func (o *LocalOwner) closeStartedDKG() {
+	o.startedDKGOnce.Do(func() { close(o.startedDKG) })
 }
 
 // Ctx returns the lifecycle context used by background goroutines.
@@ -135,10 +142,22 @@ func (o *LocalOwner) runWaitEnd(
 	errLabel, cancelLabel string,
 ) {
 	dispatch := func(res kyber_dkg.OptionResult) {
-		if err := postF(&res); err != nil {
-			o.Logger.Error(errLabel, zap.Error(err))
-			o.broadcastError(fmt.Errorf("operator ID:%d, err:%w", o.ID, err))
+		err := postF(&res)
+		if err == nil {
+			return
 		}
+		// A ctx error from postF means broadcast couldn't deliver because
+		// the owner's ctx already fired — either via Close()/reaper
+		// (Canceled) or MaxInstanceTime deadline (DeadlineExceeded). That's
+		// cleanup noise, not a ceremony failure: log at Debug and skip
+		// broadcastError (which would fail for the same reason and only
+		// double-log).
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			o.Logger.Debug("postF skipped after ctx ended", zap.String("label", errLabel), zap.Error(err))
+			return
+		}
+		o.Logger.Error(errLabel, zap.Error(err))
+		o.broadcastError(fmt.Errorf("operator ID:%d, err:%w", o.ID, err))
 	}
 	select {
 	case res := <-p.WaitEnd():
@@ -190,7 +209,7 @@ func (o *LocalOwner) StartDKG() error {
 	}
 	// Wait when the protocol exchanges finish and process the result
 	go o.runWaitEnd(p, o.PostDKG, "Error in PostDKG function", "DKG WaitEnd watcher cancelled")
-	close(o.startedDKG)
+	o.closeStartedDKG()
 	return nil
 }
 
@@ -774,7 +793,7 @@ func (o *LocalOwner) StartReshareDKGOldNodes() error {
 		return err
 	}
 	go o.runWaitEnd(p, o.PostReshare, "Error in PostReshare function", "Reshare (old nodes) WaitEnd watcher cancelled")
-	close(o.startedDKG)
+	o.closeStartedDKG()
 	return nil
 }
 
@@ -848,7 +867,7 @@ func (o *LocalOwner) StartReshareDKGNewNodes() error {
 		}
 	}
 	go o.runWaitEnd(p, o.PostReshare, "Error in PostReshare function", "Reshare (new nodes) WaitEnd watcher cancelled")
-	close(o.startedDKG)
+	o.closeStartedDKG()
 	return nil
 }
 

--- a/pkgs/dkg/drand_test.go
+++ b/pkgs/dkg/drand_test.go
@@ -1,6 +1,7 @@
 package dkg
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"sort"
@@ -77,6 +78,10 @@ func (ts *testState) ForAll(f func(o *LocalOwner) error) error {
 }
 
 func NewTestOperator(ts *testState, id uint64) (*LocalOwner, *rsa.PrivateKey) {
+	return NewTestOperatorWithCtx(ts, id, context.Background())
+}
+
+func NewTestOperatorWithCtx(ts *testState, id uint64, ctx context.Context) (*LocalOwner, *rsa.PrivateKey) {
 	pv, pk, err := spec_crypto.GenerateRSAKeys()
 	if err != nil {
 		ts.T.Error(err)
@@ -105,6 +110,7 @@ func NewTestOperator(ts *testState, id uint64) (*LocalOwner, *rsa.PrivateKey) {
 		OperatorSecretKey:  pv,
 		done:               make(chan struct{}, 1),
 		startedDKG:         make(chan struct{}, 1),
+		ctx:                ctx,
 	}, pv
 }
 

--- a/pkgs/dkg/lifecycle_test.go
+++ b/pkgs/dkg/lifecycle_test.go
@@ -1,0 +1,139 @@
+package dkg
+
+import (
+	"context"
+	"crypto/rsa"
+	"runtime"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+	"go.uber.org/zap"
+
+	spec "github.com/ssvlabs/dkg-spec"
+	spec_crypto "github.com/ssvlabs/dkg-spec/crypto"
+	wire2 "github.com/ssvlabs/ssv-dkg/pkgs/wire"
+)
+
+func TestCloseDoneIdempotent(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	owner := New(&OwnerOpts{Logger: zap.NewNop()})
+
+	owner.closeDone()
+	select {
+	case <-owner.done:
+	default:
+		t.Fatal("done channel not closed after first closeDone()")
+	}
+
+	// Subsequent calls must not panic on double-close.
+	require.NotPanics(t, owner.closeDone)
+	require.NotPanics(t, owner.closeDone)
+}
+
+func TestCloseDoneConcurrent(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	owner := New(&OwnerOpts{Logger: zap.NewNop()})
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			owner.closeDone()
+		}()
+	}
+	wg.Wait()
+
+	select {
+	case <-owner.done:
+	case <-time.After(time.Second):
+		t.Fatal("done channel not closed after concurrent closeDone calls")
+	}
+}
+
+func TestNewStoresSuppliedCtx(t *testing.T) {
+	ctx := t.Context()
+	owner := New(&OwnerOpts{Logger: zap.NewNop(), Ctx: ctx})
+	require.Same(t, ctx, owner.ctx)
+}
+
+func TestDKGCancelReleasesKyberGoroutines(t *testing.T) {
+	runtime.GC()
+	time.Sleep(50 * time.Millisecond)
+	baseline := runtime.NumGoroutine()
+
+	_, initiatorPk, err := spec_crypto.GenerateRSAKeys()
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	ts := &testState{
+		T:       t,
+		ops:     make(map[uint64]*LocalOwner),
+		opsPriv: make(map[uint64]*rsa.PrivateKey),
+		tv:      newTestVerify(),
+		ipk:     initiatorPk,
+		results: make(map[uint64][]*spec.Result),
+	}
+	const numOps = 4
+	for i := 1; i <= numOps; i++ {
+		op, priv := NewTestOperatorWithCtx(ts, uint64(i), ctx) //nolint:gosec // test values
+		ts.ops[op.ID] = op
+		ts.opsPriv[op.ID] = priv
+	}
+
+	opsarr := make([]*spec.Operator, 0, numOps)
+	for id := range ts.ops {
+		pk, err := spec_crypto.EncodeRSAPublicKey(ts.tv.ops[id])
+		require.NoError(t, err)
+		opsarr = append(opsarr, &spec.Operator{ID: id, PubKey: pk})
+	}
+	sort.SliceStable(opsarr, func(i, j int) bool { return opsarr[i].ID < opsarr[j].ID })
+
+	init := &spec.Init{
+		Operators:             opsarr,
+		T:                     3,
+		WithdrawalCredentials: spec_crypto.WithdrawalCredentials(spec_crypto.ETH1WithdrawalPrefix, common.HexToAddress("0x1234")),
+		Fork:                  [4]byte{0, 0, 0, 0},
+		Nonce:                 0,
+		Owner:                 common.HexToAddress("0x1234"),
+		Amount:                uint64(spec_crypto.MIN_ACTIVATION_BALANCE),
+	}
+
+	uid := spec.NewID()
+	exch := map[uint64]*wire2.Transport{}
+	require.NoError(t, ts.ForAll(func(o *LocalOwner) error {
+		tr, err := o.Init(uid, init)
+		exch[o.ID] = tr
+		return err
+	}))
+	require.NoError(t, ts.ForAll(func(o *LocalOwner) error {
+		return o.Broadcast(exch[o.ID])
+	}))
+	require.NoError(t, ts.ForAll(func(o *LocalOwner) error {
+		<-o.startedDKG
+		return nil
+	}))
+
+	cancel()
+
+	deadline := time.Now().Add(1 * time.Second)
+	for time.Now().Before(deadline) {
+		runtime.GC()
+		if runtime.NumGoroutine() <= baseline+2 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	require.LessOrEqualf(t, runtime.NumGoroutine(), baseline+2,
+		"kyber residue not released within 1s of cancel (baseline=%d, now=%d)",
+		baseline, runtime.NumGoroutine())
+
+	goleak.VerifyNone(t, goleak.IgnoreCurrent())
+}

--- a/pkgs/dkg/lifecycle_test.go
+++ b/pkgs/dkg/lifecycle_test.go
@@ -3,7 +3,6 @@ package dkg
 import (
 	"context"
 	"crypto/rsa"
-	"runtime"
 	"sort"
 	"sync"
 	"testing"
@@ -22,7 +21,7 @@ import (
 func TestCloseDoneIdempotent(t *testing.T) {
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 
-	owner := New(&OwnerOpts{Logger: zap.NewNop()})
+	owner := New(t.Context(), &OwnerOpts{Logger: zap.NewNop()})
 
 	owner.closeDone()
 	select {
@@ -39,7 +38,7 @@ func TestCloseDoneIdempotent(t *testing.T) {
 func TestCloseDoneConcurrent(t *testing.T) {
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 
-	owner := New(&OwnerOpts{Logger: zap.NewNop()})
+	owner := New(t.Context(), &OwnerOpts{Logger: zap.NewNop()})
 
 	var wg sync.WaitGroup
 	for i := 0; i < 50; i++ {
@@ -60,14 +59,16 @@ func TestCloseDoneConcurrent(t *testing.T) {
 
 func TestNewStoresSuppliedCtx(t *testing.T) {
 	ctx := t.Context()
-	owner := New(&OwnerOpts{Logger: zap.NewNop(), Ctx: ctx})
+	owner := New(ctx, &OwnerOpts{Logger: zap.NewNop()})
 	require.Same(t, ctx, owner.ctx)
 }
 
 func TestDKGCancelReleasesKyberGoroutines(t *testing.T) {
-	runtime.GC()
-	time.Sleep(50 * time.Millisecond)
-	baseline := runtime.NumGoroutine()
+	// goleak.VerifyNone is the authoritative check; runtime.NumGoroutine
+	// pre-bound was removed because it picks up runtime-internal goroutines
+	// whose counts fluctuate under -race CI and produced flakes without
+	// adding signal.
+	ignore := goleak.IgnoreCurrent()
 
 	_, initiatorPk, err := spec_crypto.GenerateRSAKeys()
 	require.NoError(t, err)
@@ -123,17 +124,6 @@ func TestDKGCancelReleasesKyberGoroutines(t *testing.T) {
 
 	cancel()
 
-	deadline := time.Now().Add(1 * time.Second)
-	for time.Now().Before(deadline) {
-		runtime.GC()
-		if runtime.NumGoroutine() <= baseline+2 {
-			break
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
-	require.LessOrEqualf(t, runtime.NumGoroutine(), baseline+2,
-		"kyber residue not released within 1s of cancel (baseline=%d, now=%d)",
-		baseline, runtime.NumGoroutine())
-
-	goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	// goleak will retry internally for a short window to let goroutines drain.
+	goleak.VerifyNone(t, ignore)
 }

--- a/pkgs/dkg/lifecycle_test.go
+++ b/pkgs/dkg/lifecycle_test.go
@@ -64,10 +64,12 @@ func TestNewStoresSuppliedCtx(t *testing.T) {
 }
 
 func TestDKGCancelReleasesKyberGoroutines(t *testing.T) {
-	// goleak.VerifyNone is the authoritative check; runtime.NumGoroutine
-	// pre-bound was removed because it picks up runtime-internal goroutines
-	// whose counts fluctuate under -race CI and produced flakes without
-	// adding signal.
+	// The goroutine chain spawned by StartDKG (cancellablePhaser,
+	// kyber Protocol.Start, runWaitEnd) exits promptly on ctx cancel —
+	// cancellablePhaser emits FinishPhase, kyber reads it and returns,
+	// runWaitEnd observes the final result. require.Eventually below polls
+	// goleak.Find to tolerate loaded-CI scheduling without the flaky
+	// runtime.NumGoroutine pre-bound the prior version relied on.
 	ignore := goleak.IgnoreCurrent()
 
 	_, initiatorPk, err := spec_crypto.GenerateRSAKeys()
@@ -124,6 +126,7 @@ func TestDKGCancelReleasesKyberGoroutines(t *testing.T) {
 
 	cancel()
 
-	// goleak will retry internally for a short window to let goroutines drain.
-	goleak.VerifyNone(t, ignore)
+	require.Eventually(t, func() bool {
+		return goleak.Find(ignore) == nil
+	}, 2*time.Second, 50*time.Millisecond, "kyber goroutines did not exit after cancel")
 }

--- a/pkgs/operator/instance.go
+++ b/pkgs/operator/instance.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rsa"
 	"fmt"
+	"sync"
 
 	"go.uber.org/zap"
 
@@ -27,6 +28,10 @@ type instWrapper struct {
 	InitiatorPublicKey *rsa.PublicKey // initiator's RSA public key to verify its identity. Makes sure that in the DKG process messages received only from one initiator who started it.
 	respChan           chan []byte    // channel to receive response
 	cancel             context.CancelFunc
+	// procMu serializes ProcessMessages per instance. LocalOwner mutates
+	// exchanges/deals maps and closes startedDKG without its own locking;
+	// concurrent /dkg retries for the same InstanceID would race those.
+	procMu sync.Mutex
 }
 
 func (iw *instWrapper) Close() {
@@ -49,6 +54,9 @@ func (iw *instWrapper) VerifyInitiatorMessage(msg, sig []byte) error {
 }
 
 func (iw *instWrapper) ProcessMessages(msg *wire.MultipleSignedTransports) ([]byte, error) {
+	iw.procMu.Lock()
+	defer iw.procMu.Unlock()
+
 	var multipleMsgsBytes []byte
 	for _, transportMsg := range msg.Messages {
 		msgBytes, err := transportMsg.MarshalSSZ()
@@ -82,18 +90,21 @@ func (iw *instWrapper) ProcessMessages(msg *wire.MultipleSignedTransports) ([]by
 			return nil, fmt.Errorf("process message: failed to process dkg message: %w", err)
 		}
 	}
-	// Derive from the lifecycle ctx so Close() short-circuits this wait.
-	ctx, cancel := context.WithTimeout(iw.Ctx(), MaxInstancePhaseTimeout)
-	defer cancel()
+	// Phase ctx is Background-derived so the per-call budget is not shrunk by
+	// instance age. iw.Ctx() is observed separately so Close()/reaper
+	// cancellation still short-circuits the wait.
+	phaseCtx, phaseCancel := context.WithTimeout(context.Background(), MaxInstancePhaseTimeout)
+	defer phaseCancel()
 	select {
 	case resp, ok := <-iw.respChan:
 		if !ok {
 			return nil, fmt.Errorf("process message: response channel closed")
 		}
 		return resp, nil
-	case <-ctx.Done():
-		// Broadcast's ctx-priority prevents post-cancel writes, so a non-blocking
-		// re-check catches a response queued just before cancel.
+	case <-phaseCtx.Done():
+		// Broadcast checks instanceCtx before writing but the check-then-send
+		// is a TOCTOU — a response can land in respChan concurrently with
+		// phase deadline. The non-blocking re-check catches that window.
 		select {
 		case resp, ok := <-iw.respChan:
 			if !ok {
@@ -101,7 +112,18 @@ func (iw *instWrapper) ProcessMessages(msg *wire.MultipleSignedTransports) ([]by
 			}
 			return resp, nil
 		default:
-			return nil, fmt.Errorf("process message: timed out waiting for response: %w", ctx.Err())
+			return nil, fmt.Errorf("process message: timed out waiting for response: %w", phaseCtx.Err())
+		}
+	case <-iw.Ctx().Done():
+		// Instance lifecycle ended (Close, reaper, or MaxInstanceTime).
+		select {
+		case resp, ok := <-iw.respChan:
+			if !ok {
+				return nil, fmt.Errorf("process message: response channel closed")
+			}
+			return resp, nil
+		default:
+			return nil, fmt.Errorf("process message: instance lifecycle ended: %w", iw.Ctx().Err())
 		}
 	}
 }

--- a/pkgs/operator/instance.go
+++ b/pkgs/operator/instance.go
@@ -17,6 +17,8 @@ import (
 type Instance interface {
 	ProcessMessages(msg *wire.MultipleSignedTransports) ([]byte, error)
 	VerifyInitiatorMessage(msg, sig []byte) error
+	// Close cancels in-flight goroutines bound to this instance. Idempotent.
+	Close()
 }
 
 // instWrapper wraps LocalOwner instance with RSA public key
@@ -24,6 +26,13 @@ type instWrapper struct {
 	*dkg.LocalOwner                   // main DKG ceremony instance
 	InitiatorPublicKey *rsa.PublicKey // initiator's RSA public key to verify its identity. Makes sure that in the DKG process messages received only from one initiator who started it.
 	respChan           chan []byte    // channel to receive response
+	cancel             context.CancelFunc
+}
+
+func (iw *instWrapper) Close() {
+	if iw.cancel != nil {
+		iw.cancel()
+	}
 }
 
 // VerifyInitiatorMessage verifies initiator message signature
@@ -73,7 +82,8 @@ func (iw *instWrapper) ProcessMessages(msg *wire.MultipleSignedTransports) ([]by
 			return nil, fmt.Errorf("process message: failed to process dkg message: %w", err)
 		}
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), MaxInstancePhaseTimeout)
+	// Derive from the lifecycle ctx so Close() short-circuits this wait.
+	ctx, cancel := context.WithTimeout(iw.Ctx(), MaxInstancePhaseTimeout)
 	defer cancel()
 	select {
 	case resp, ok := <-iw.respChan:
@@ -82,6 +92,16 @@ func (iw *instWrapper) ProcessMessages(msg *wire.MultipleSignedTransports) ([]by
 		}
 		return resp, nil
 	case <-ctx.Done():
-		return nil, fmt.Errorf("process message: timed out waiting for response: %w", ctx.Err())
+		// Broadcast's ctx-priority prevents post-cancel writes, so a non-blocking
+		// re-check catches a response queued just before cancel.
+		select {
+		case resp, ok := <-iw.respChan:
+			if !ok {
+				return nil, fmt.Errorf("process message: response channel closed")
+			}
+			return resp, nil
+		default:
+			return nil, fmt.Errorf("process message: timed out waiting for response: %w", ctx.Err())
+		}
 	}
 }

--- a/pkgs/operator/instances_manager.go
+++ b/pkgs/operator/instances_manager.go
@@ -67,9 +67,8 @@ func (s *Switch) CreateInstance(reqID [24]byte, operators []*spec.Operator, mess
 		InitiatorPublicKey: initiatorPublicKey,
 		OperatorSecretKey:  s.PrivateKey,
 		Version:            s.Version,
-		Ctx:                instanceCtx,
 	}
-	owner := dkg.New(&opts)
+	owner := dkg.New(instanceCtx, &opts)
 	var resp *wire.Transport
 	// wait for exchange msg
 	switch msg := message.(type) {
@@ -107,7 +106,12 @@ func (s *Switch) CreateInstance(reqID [24]byte, operators []*spec.Operator, mess
 			return nil, nil, fmt.Errorf("create instance: response channel closed")
 		}
 		success = true
-		return &instWrapper{owner, initiatorPublicKey, bchan, cancelInstance}, res, nil
+		return &instWrapper{
+			LocalOwner:         owner,
+			InitiatorPublicKey: initiatorPublicKey,
+			respChan:           bchan,
+			cancel:             cancelInstance,
+		}, res, nil
 	case <-waitCtx.Done():
 		return nil, nil, fmt.Errorf("create instance: timed out waiting for initial response: %w", waitCtx.Err())
 	}

--- a/pkgs/operator/instances_manager.go
+++ b/pkgs/operator/instances_manager.go
@@ -30,10 +30,31 @@ func (s *Switch) CreateInstance(reqID [24]byte, operators []*spec.Operator, mess
 	if s.OperatorID != operatorID {
 		return nil, nil, fmt.Errorf("wrong operator ID: want %d, got %d", s.OperatorID, operatorID)
 	}
+	// Lifecycle ctx for the LocalOwner's background goroutines. WithTimeout
+	// bounds it by MaxInstanceTime so abandoned instances release goroutines
+	// even if no later cleanup sweep runs.
+	instanceCtx, cancelInstance := context.WithTimeout(context.Background(), MaxInstanceTime)
+	var success bool
+	defer func() {
+		if !success {
+			cancelInstance()
+		}
+	}()
 	bchan := make(chan []byte, 1)
 	broadcast := func(msg []byte) error {
-		bchan <- msg
-		return nil
+		// A cancelled instance must not enqueue a stale response that a
+		// racing ProcessMessages could read as a real reply.
+		select {
+		case <-instanceCtx.Done():
+			return instanceCtx.Err()
+		default:
+		}
+		select {
+		case bchan <- msg:
+			return nil
+		case <-instanceCtx.Done():
+			return instanceCtx.Err()
+		}
 	}
 	opts := dkg.OwnerOpts{
 		Logger:             s.Logger.With(zap.String("instance", hex.EncodeToString(reqID[:]))),
@@ -46,6 +67,7 @@ func (s *Switch) CreateInstance(reqID [24]byte, operators []*spec.Operator, mess
 		InitiatorPublicKey: initiatorPublicKey,
 		OperatorSecretKey:  s.PrivateKey,
 		Version:            s.Version,
+		Ctx:                instanceCtx,
 	}
 	owner := dkg.New(&opts)
 	var resp *wire.Transport
@@ -77,16 +99,17 @@ func (s *Switch) CreateInstance(reqID [24]byte, operators []*spec.Operator, mess
 	if err := owner.Broadcast(resp); err != nil {
 		return nil, nil, err
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), MaxInstancePhaseTimeout)
-	defer cancel()
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), MaxInstancePhaseTimeout)
+	defer waitCancel()
 	select {
 	case res, ok := <-bchan:
 		if !ok {
 			return nil, nil, fmt.Errorf("create instance: response channel closed")
 		}
-		return &instWrapper{owner, initiatorPublicKey, bchan}, res, nil
-	case <-ctx.Done():
-		return nil, nil, fmt.Errorf("create instance: timed out waiting for initial response: %w", ctx.Err())
+		success = true
+		return &instWrapper{owner, initiatorPublicKey, bchan, cancelInstance}, res, nil
+	case <-waitCtx.Done():
+		return nil, nil, fmt.Errorf("create instance: timed out waiting for initial response: %w", waitCtx.Err())
 	}
 }
 
@@ -135,11 +158,15 @@ func (s *Switch) InitInstance(reqID [24]byte, initMsg *wire.Transport, initiator
 	return resp, nil
 }
 
-// cleanInstances removes all instances at Switch
+// cleanInstances removes expired instances and cancels their goroutines.
+// Caller must hold s.Mtx; Close() is lock-free so calling it under lock is safe.
 func (s *Switch) cleanInstances() int {
 	count := 0
 	for id, instime := range s.InstanceInitTime {
 		if time.Now().After(instime.Add(MaxInstanceTime)) {
+			if inst, ok := s.Instances[id]; ok {
+				inst.Close()
+			}
 			delete(s.Instances, id)
 			delete(s.InstanceInitTime, id)
 			count++
@@ -277,21 +304,22 @@ func (s *Switch) HandleInstanceOperation(reqID [24]byte, transportMsg *wire.Tran
 // Helper functions to abstract out common behavior
 func (s *Switch) validateInstances(reqID InstanceID) error {
 	s.Mtx.Lock()
+	// Sweep on every admission so below-capacity abandoned instances don't
+	// linger until MaxInstances is hit.
+	s.cleanInstances()
 	l := len(s.Instances)
 	if l >= MaxInstances {
-		cleaned := s.cleanInstances()
-		if l-cleaned >= MaxInstances {
-			s.Mtx.Unlock()
-			return utils.ErrMaxInstances
-		}
+		s.Mtx.Unlock()
+		return utils.ErrMaxInstances
 	}
-	_, ok := s.Instances[reqID]
+	existing, ok := s.Instances[reqID]
 	if ok {
 		tm := s.InstanceInitTime[reqID]
 		if time.Now().Before(tm.Add(MaxInstanceTime)) {
 			s.Mtx.Unlock()
 			return utils.ErrAlreadyExists
 		}
+		existing.Close()
 		delete(s.Instances, reqID)
 		delete(s.InstanceInitTime, reqID)
 	}

--- a/pkgs/operator/lifecycle_test.go
+++ b/pkgs/operator/lifecycle_test.go
@@ -1,0 +1,124 @@
+package operator
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+
+	"github.com/ssvlabs/ssv-dkg/pkgs/wire"
+)
+
+type trackedInstance struct {
+	closed atomic.Bool
+}
+
+func (t *trackedInstance) ProcessMessages(*wire.MultipleSignedTransports) ([]byte, error) {
+	return nil, fmt.Errorf("not used in test: %w", context.DeadlineExceeded)
+}
+
+func (t *trackedInstance) VerifyInitiatorMessage([]byte, []byte) error { return nil }
+
+func (t *trackedInstance) Close() { t.closed.Store(true) }
+
+func TestCleanInstancesClosesExpired(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	var liveID, expiredID InstanceID
+	copy(liveID[:], "live-instance-id-01234567")
+	copy(expiredID[:], "expired-instance-01234567")
+
+	live := &trackedInstance{}
+	expired := &trackedInstance{}
+
+	s := &Switch{
+		Instances: map[InstanceID]Instance{liveID: live, expiredID: expired},
+		InstanceInitTime: map[InstanceID]time.Time{
+			liveID:    time.Now(),
+			expiredID: time.Now().Add(-2 * MaxInstanceTime),
+		},
+	}
+
+	count := s.cleanInstances()
+	require.Equal(t, 1, count)
+	require.False(t, live.closed.Load(), "live instance must not be closed")
+	require.True(t, expired.closed.Load(), "expired instance must be closed")
+	require.Len(t, s.Instances, 1)
+	_, stillThere := s.Instances[liveID]
+	require.True(t, stillThere)
+}
+
+func TestValidateInstancesClosesCollidingExpired(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	var reqID InstanceID
+	copy(reqID[:], "test-instance-id-0123456")
+
+	expired := &trackedInstance{}
+	s := &Switch{
+		Instances:        map[InstanceID]Instance{reqID: expired},
+		InstanceInitTime: map[InstanceID]time.Time{reqID: time.Now().Add(-2 * MaxInstanceTime)},
+	}
+
+	require.NoError(t, s.validateInstances(reqID))
+	require.True(t, expired.closed.Load(), "expired colliding instance must be closed")
+	require.Empty(t, s.Instances)
+}
+
+func TestInstWrapperCloseCancelsLifecycleCtx(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	ctx, cancel := context.WithCancel(t.Context())
+	iw := &instWrapper{cancel: cancel}
+
+	iw.Close()
+	select {
+	case <-ctx.Done():
+		// expected
+	case <-time.After(time.Second):
+		t.Fatal("Close did not cancel the lifecycle context")
+	}
+
+	require.NotPanics(t, iw.Close)
+	require.NotPanics(t, iw.Close)
+}
+
+func TestReaperSweepsExpiredInstancesAndStops(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	var expiredID, liveID InstanceID
+	copy(expiredID[:], "expired-instance-01234567")
+	copy(liveID[:], "live-instance-id-01234567")
+
+	expired := &trackedInstance{}
+	live := &trackedInstance{}
+
+	s := &Switch{
+		Instances: map[InstanceID]Instance{expiredID: expired, liveID: live},
+		InstanceInitTime: map[InstanceID]time.Time{
+			expiredID: time.Now().Add(-2 * MaxInstanceTime),
+			liveID:    time.Now(),
+		},
+	}
+
+	s.StartReaper(10 * time.Millisecond)
+	defer s.StopReaper()
+
+	require.Eventually(t, func() bool {
+		s.Mtx.RLock()
+		_, stillThere := s.Instances[expiredID]
+		s.Mtx.RUnlock()
+		return !stillThere
+	}, time.Second, 20*time.Millisecond)
+
+	require.True(t, expired.closed.Load())
+	require.False(t, live.closed.Load())
+	s.Mtx.RLock()
+	_, liveStillThere := s.Instances[liveID]
+	s.Mtx.RUnlock()
+	require.True(t, liveStillThere)
+}

--- a/pkgs/operator/operator.go
+++ b/pkgs/operator/operator.go
@@ -1,6 +1,7 @@
 package operator
 
 import (
+	"context"
 	"crypto/rsa"
 	"errors"
 	"fmt"
@@ -83,6 +84,19 @@ func (s *Server) Start(port uint16, cert, key string) error {
 			return nil
 		}
 		return err
+	}
+	return nil
+}
+
+// Stop gracefully shuts the HTTP server down and stops the Switch's background
+// reaper. Safe to call multiple times and when Start never ran. ctx bounds the
+// HTTP server's graceful-drain window.
+func (s *Server) Stop(ctx context.Context) error {
+	if s.State != nil {
+		s.State.StopReaper()
+	}
+	if s.HttpServer != nil {
+		return s.HttpServer.Shutdown(ctx)
 	}
 	return nil
 }

--- a/pkgs/operator/operator.go
+++ b/pkgs/operator/operator.go
@@ -60,6 +60,7 @@ func New(key *rsa.PrivateKey, logger *zap.Logger, ver []byte, id uint64, outputP
 		return nil, fmt.Errorf("failed to connect to Ethereum backend, err: %w", err)
 	}
 	swtch := NewSwitch(key, logger, ver, pkBytes, id, ethBackend)
+	swtch.StartReaper(ReaperInterval)
 	s := &Server{
 		Logger:     logger,
 		Router:     r,

--- a/pkgs/operator/state.go
+++ b/pkgs/operator/state.go
@@ -49,6 +49,7 @@ type Switch struct {
 	PubKeyBytes      []byte
 	OperatorID       uint64
 	EthClient        eip1271.ETHClient
+	reaperOnce       sync.Once
 	reaperCancel     context.CancelFunc
 }
 
@@ -123,12 +124,15 @@ func NewSwitch(pv *rsa.PrivateKey, logger *zap.Logger, ver, pkBytes []byte, id u
 
 // StartReaper spawns a background goroutine that periodically sweeps expired
 // instances so abandoned ceremonies release heap pressure even when admission
-// traffic is sparse. Safe to call at most once per Switch. Stop with StopReaper
-// before the process exits or the Switch is discarded in tests.
+// traffic is sparse. Idempotent — only the first call spawns a reaper; later
+// calls are no-ops. Stop with StopReaper before the process exits or the
+// Switch is discarded in tests.
 func (s *Switch) StartReaper(interval time.Duration) {
-	ctx, cancel := context.WithCancel(context.Background())
-	s.reaperCancel = cancel
-	go s.runReaper(ctx, interval)
+	s.reaperOnce.Do(func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		s.reaperCancel = cancel
+		go s.runReaper(ctx, interval)
+	})
 }
 
 // StopReaper cancels the background sweeper started by StartReaper. No-op if
@@ -173,7 +177,7 @@ func (s *Switch) ProcessMessage(dkgMsg []byte) ([]byte, error) {
 		return nil, utils.ErrMissingInstance
 	}
 	resp, err := inst.ProcessMessages(st)
-	if errors.Is(err, context.DeadlineExceeded) {
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
 		s.Mtx.Lock()
 		current, ok := s.Instances[id]
 		if ok && current == inst {

--- a/pkgs/operator/state.go
+++ b/pkgs/operator/state.go
@@ -30,6 +30,11 @@ const MaxInstances = 1024
 const MaxInstanceTime = 1 * time.Minute
 const MaxInstancePhaseTimeout = MaxInstanceTime
 
+// ReaperInterval is how often the background reaper sweeps expired instances
+// when StartReaper is running. Kept below MaxInstanceTime so map entries
+// don't accumulate heap pressure between admission bursts.
+const ReaperInterval = 30 * time.Second
+
 // InstanceID each new DKG ceremony has a unique random ID that we can identify messages and be able to process them in parallel
 type InstanceID [24]byte
 
@@ -44,6 +49,7 @@ type Switch struct {
 	PubKeyBytes      []byte
 	OperatorID       uint64
 	EthClient        eip1271.ETHClient
+	reaperCancel     context.CancelFunc
 }
 
 func (s *Switch) getPublicCommitsAndSecretShare(reshareMsg *wire.ReshareMessage) ([]kyber.Point, *kyber_dkg.DistKeyShare, error) {
@@ -115,6 +121,39 @@ func NewSwitch(pv *rsa.PrivateKey, logger *zap.Logger, ver, pkBytes []byte, id u
 	}
 }
 
+// StartReaper spawns a background goroutine that periodically sweeps expired
+// instances so abandoned ceremonies release heap pressure even when admission
+// traffic is sparse. Safe to call at most once per Switch. Stop with StopReaper
+// before the process exits or the Switch is discarded in tests.
+func (s *Switch) StartReaper(interval time.Duration) {
+	ctx, cancel := context.WithCancel(context.Background())
+	s.reaperCancel = cancel
+	go s.runReaper(ctx, interval)
+}
+
+// StopReaper cancels the background sweeper started by StartReaper. No-op if
+// StartReaper was never called.
+func (s *Switch) StopReaper() {
+	if s.reaperCancel != nil {
+		s.reaperCancel()
+	}
+}
+
+func (s *Switch) runReaper(ctx context.Context, interval time.Duration) {
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-t.C:
+			s.Mtx.Lock()
+			s.cleanInstances()
+			s.Mtx.Unlock()
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
 // ProcessMessage processes incoming message to /dkg route
 func (s *Switch) ProcessMessage(dkgMsg []byte) ([]byte, error) {
 	// get instanceID
@@ -142,6 +181,8 @@ func (s *Switch) ProcessMessage(dkgMsg []byte) ([]byte, error) {
 			delete(s.InstanceInitTime, id)
 		}
 		s.Mtx.Unlock()
+		// Close is idempotent; safe even if another cleanup path beat us.
+		inst.Close()
 	}
 	return resp, err
 }

--- a/pkgs/operator/state_test.go
+++ b/pkgs/operator/state_test.go
@@ -159,7 +159,7 @@ func TestInitInstance(t *testing.T) {
 				return nil, fmt.Errorf("init: create instance: %w", err)
 			}
 			swtch.State.Mtx.Lock()
-			swtch.State.Instances[reqID] = &instWrapper{&dkg.LocalOwner{}, initiatorPubKey, make(chan []byte, 1)}
+			swtch.State.Instances[reqID] = &instWrapper{&dkg.LocalOwner{}, initiatorPubKey, make(chan []byte, 1), func() {}}
 			swtch.State.InstanceInitTime[reqID] = time.Now()
 			swtch.State.Mtx.Unlock()
 			return resp, nil

--- a/pkgs/operator/state_test.go
+++ b/pkgs/operator/state_test.go
@@ -159,7 +159,12 @@ func TestInitInstance(t *testing.T) {
 				return nil, fmt.Errorf("init: create instance: %w", err)
 			}
 			swtch.State.Mtx.Lock()
-			swtch.State.Instances[reqID] = &instWrapper{&dkg.LocalOwner{}, initiatorPubKey, make(chan []byte, 1), func() {}}
+			swtch.State.Instances[reqID] = &instWrapper{
+				LocalOwner:         &dkg.LocalOwner{},
+				InitiatorPublicKey: initiatorPubKey,
+				respChan:           make(chan []byte, 1),
+				cancel:             func() {},
+			}
 			swtch.State.InstanceInitTime[reqID] = time.Now()
 			swtch.State.Mtx.Unlock()
 			return resp, nil

--- a/pkgs/operator/state_timeout_test.go
+++ b/pkgs/operator/state_timeout_test.go
@@ -19,6 +19,8 @@ func (timeoutInstance) ProcessMessages(*wire.MultipleSignedTransports) ([]byte, 
 
 func (timeoutInstance) VerifyInitiatorMessage([]byte, []byte) error { return nil }
 
+func (timeoutInstance) Close() {}
+
 func TestProcessMessage_DeletesInstanceOnTimeout(t *testing.T) {
 	var instanceID InstanceID
 	copy(instanceID[:], "test-instance-id-0123456")

--- a/pkgs/wire/dkg.go
+++ b/pkgs/wire/dkg.go
@@ -1,6 +1,7 @@
 package wire
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -27,14 +28,16 @@ func (l *LogWrapper) Error(vals ...interface{}) {
 	l.Logger.Error(fmt.Sprint(vals...))
 }
 
-// NewDKGProtocol initializes and starts phases of the DKG protocol
-func NewDKGProtocol(dkgConfig *dkg.Config, b dkg.Board, logger *zap.Logger) (*dkg.Protocol, error) {
+// NewDKGProtocol initializes the DKG protocol. The returned protocol is driven
+// by a cancellable phaser so ctx cancellation winds the kyber goroutine down
+// within one phase signal. ctx must be non-nil.
+func NewDKGProtocol(ctx context.Context, dkgConfig *dkg.Config, b dkg.Board, logger *zap.Logger) (*dkg.Protocol, error) {
 	dkgLogger := New(logger)
 	dkgConfig.Log = dkgLogger
 	// Phaser must signal on its channel when the protocol should move to a next
 	// phase. Phase must be sequential: DealPhase (start), ResponsePhase,
 	// JustifPhase and then FinishPhase.
-	phaser := dkg.NewTimePhaser(time.Second * 10)
+	phaser := newCancellablePhaser(ctx, 10*time.Second)
 	ret, err := dkg.NewProtocol(
 		dkgConfig,
 		b,

--- a/pkgs/wire/phaser.go
+++ b/pkgs/wire/phaser.go
@@ -1,0 +1,96 @@
+package wire
+
+import (
+	"context"
+	"time"
+
+	"github.com/drand/kyber/share/dkg"
+)
+
+// cancellablePhaser is a dkg.Phaser that emits phases on a fixed cadence but
+// exits when ctx is cancelled, enqueueing FinishPhase so kyber's Protocol.Start
+// loop can observe it and return.
+type cancellablePhaser struct {
+	ctx   context.Context
+	out   chan dkg.Phase
+	sleep time.Duration
+}
+
+func newCancellablePhaser(ctx context.Context, sleep time.Duration) *cancellablePhaser {
+	return &cancellablePhaser{
+		ctx:   ctx,
+		out:   make(chan dkg.Phase, 4), // matches kyber's default TimePhaser buffer
+		sleep: sleep,
+	}
+}
+
+func (p *cancellablePhaser) NextPhase() chan dkg.Phase {
+	return p.out
+}
+
+// Start runs the phase progression in the calling goroutine. On ctx cancel it
+// enqueues FinishPhase (best-effort) and returns.
+func (p *cancellablePhaser) Start() {
+	signalFinish := func() {
+		select {
+		case p.out <- dkg.FinishPhase:
+		default:
+		}
+	}
+	// Once cancelled, only FinishPhase may go out — never a real phase.
+	send := func(ph dkg.Phase) bool {
+		select {
+		case <-p.ctx.Done():
+			signalFinish()
+			return false
+		default:
+		}
+		select {
+		case p.out <- ph:
+			return true
+		case <-p.ctx.Done():
+			signalFinish()
+			return false
+		}
+	}
+	wait := func() bool {
+		if p.sleep <= 0 {
+			return true
+		}
+		select {
+		case <-p.ctx.Done():
+			signalFinish()
+			return false
+		default:
+		}
+		t := time.NewTimer(p.sleep)
+		defer t.Stop()
+		select {
+		case <-t.C:
+			return true
+		case <-p.ctx.Done():
+			signalFinish()
+			return false
+		}
+	}
+
+	if !send(dkg.DealPhase) {
+		return
+	}
+	if !wait() {
+		return
+	}
+	if !send(dkg.ResponsePhase) {
+		return
+	}
+	if !wait() {
+		return
+	}
+	if !send(dkg.JustifPhase) {
+		return
+	}
+	if !wait() {
+		return
+	}
+	send(dkg.FinishPhase)
+}

--- a/pkgs/wire/phaser_test.go
+++ b/pkgs/wire/phaser_test.go
@@ -1,0 +1,113 @@
+package wire
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/drand/kyber/share/dkg"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+)
+
+func TestCancellablePhaser_EmitsAllPhasesWhenNotCancelled(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	p := newCancellablePhaser(t.Context(), 0)
+	done := make(chan struct{})
+	go func() {
+		p.Start()
+		close(done)
+	}()
+
+	phases := []dkg.Phase{dkg.DealPhase, dkg.ResponsePhase, dkg.JustifPhase, dkg.FinishPhase}
+	for _, want := range phases {
+		select {
+		case got := <-p.NextPhase():
+			require.Equal(t, want, got)
+		case <-time.After(time.Second):
+			t.Fatalf("timed out waiting for phase %s", want)
+		}
+	}
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Start did not return after final phase")
+	}
+}
+
+func TestCancellablePhaser_ExitsPromptlyOnCancel(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	ctx, cancel := context.WithCancel(t.Context())
+	// 10s sleep would normally force a 30s total; we cancel immediately so the
+	// phaser must short-circuit.
+	p := newCancellablePhaser(ctx, 10*time.Second)
+
+	done := make(chan struct{})
+	start := time.Now()
+	go func() {
+		p.Start()
+		close(done)
+	}()
+
+	// First phase should still go out before we cancel.
+	select {
+	case got := <-p.NextPhase():
+		require.Equal(t, dkg.DealPhase, got)
+	case <-time.After(time.Second):
+		t.Fatal("DealPhase not emitted before cancel")
+	}
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Start did not return within 1s of ctx cancel")
+	}
+
+	require.Less(t, time.Since(start), 2*time.Second, "cancel path must beat the 30s TimePhaser cadence")
+
+	// FinishPhase must be queued so kyber Protocol.Start exits on next read.
+	var sawFinish bool
+	for {
+		select {
+		case ph := <-p.NextPhase():
+			if ph == dkg.FinishPhase {
+				sawFinish = true
+			}
+		default:
+			require.True(t, sawFinish, "FinishPhase must be enqueued on cancel to wind kyber down")
+			return
+		}
+	}
+}
+
+func TestCancellablePhaser_CancelBeforeStart(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	p := newCancellablePhaser(ctx, 10*time.Second)
+	done := make(chan struct{})
+	go func() {
+		p.Start()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Start did not return when ctx was pre-cancelled")
+	}
+
+	select {
+	case ph := <-p.NextPhase():
+		require.Equal(t, dkg.FinishPhase, ph, "pre-cancelled Start should still emit FinishPhase")
+	default:
+		t.Fatal("FinishPhase not enqueued for pre-cancelled ctx")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes v3.1.0 QA 2.6 "goroutine cleanup — memory leaks still persist." Threads a lifecycle context through `LocalOwner` + `instWrapper`, replaces kyber's `TimePhaser` with a cancel-aware version, and adds a background reaper so expired instances release heap pressure under sparse traffic.

## What's fixed

- **PostReshare `<-o.done` deadlock** on the success path — nothing ever sent to `o.done`, so every successful reshare leaked its WaitEnd goroutine. `sync.Once`-guarded close now used across `PostDKG`, `PostReshare`, `broadcastError`.
- **Orphaned `bchan` senders** on timeout — broadcast closure exits via `instanceCtx.Done()`.
- **WaitEnd watchers outliving the instance** — `runWaitEnd` races `WaitEnd()` against `ctx.Done()` with a 5s grace for late completions.
- **kyber `TimePhaser` residue (~30s)** — replaced with `cancellablePhaser` in `pkgs/wire/phaser.go`; kyber exits within one phase signal.
- **Instance lifecycle**: `Instance.Close()` plumbed into `ProcessMessage` timeout, `cleanInstances`, `validateInstances`; `ProcessMessages` honors the lifecycle ctx.
- **Heap retention**: `Switch.StartReaper` sweeps expired entries every 30s.

## Scope

**In:** goroutine lifecycle, kyber cancellation, instance eviction, heap-retention reaper.

**Deferred** (future releases): error-code unification (1.4 / 1.5 / 2.3), Pong version (4.1), body-limit tightening (2.1), atomic `MaxInstances` cap, CLI, Docker/CI, streaming SSZ.

## Known limitations

- Post-cancel broadcast can rarely deliver a legitimate result to an in-flight caller (no leak; real work).
- Under extreme concurrent admissions, `MaxInstances=1024` may briefly overshoot by the number of in-flight admission goroutines.

## Test plan

- [x] `go test -race -timeout 300s ./pkgs/...` — all pass
- [x] `golangci-lint run ./pkgs/...` — 0 issues
- [x] New: `pkgs/wire/phaser_test.go`, `pkgs/dkg/lifecycle_test.go`, `pkgs/operator/lifecycle_test.go`; goleak verifies kyber residue clears on cancel via `TestDKGCancelReleasesKyberGoroutines`
- [ ] QA 2.8 EIP-1271 integration tests re-run
- [ ] Full v3.1.0 QA re-pass under sustained + timeout-storm traffic
