### PR TITLE
fix: bind resign/reshare validation to operator and owner identity

### DIFF
--- a/integration_test/resign_integration_test.go
+++ b/integration_test/resign_integration_test.go
@@ -79,6 +79,42 @@ func TestInitResignChangeOwnerRejected(t *testing.T) {
 		require.NoError(t, err)
 		rMsgs := []*wire.ResignMessage{rMsg}
 		_, _, _, err = executeResign(t, clnt, rMsgs, sk)
-		require.ErrorContains(t, err, "invalid owner address")
+		// the owner signature is checked against the resign message owner, so a message
+		// naming a different owner than the one that signed it stops at that check
+		require.ErrorContains(t, err, string(wire.InitiatorErrorCodeCeremonyFailed))
+	})
+}
+
+func TestInitResignProofOwnerMismatchRejected(t *testing.T) {
+	t.Parallel()
+	env := setupDynamicTest(t)
+	clnt, err := initiator.New(env.ops, env.logger, testVersion, rootCert, false)
+	require.NoError(t, err)
+	withdraw := newEthAddress(t)
+	sk, err := eth_crypto.GenerateKey()
+	require.NoError(t, err)
+	owner := eth_crypto.PubkeyToAddress(sk.PublicKey)
+	skOtherOwner, err := eth_crypto.GenerateKey()
+	require.NoError(t, err)
+	otherOwner := eth_crypto.PubkeyToAddress(skOtherOwner.PublicKey)
+	t.Run("4 operators proof owner mismatch rejected", func(t *testing.T) {
+		id := spec.NewID()
+		depositData, ks, proofs, err := clnt.StartDKG(id, eth1Creds(withdraw), []uint64{11, 22, 33, 44}, "holesky", owner, 0, uint64(spec_crypto.MIN_ACTIVATION_BALANCE))
+		require.NoError(t, err)
+		err = validator.ValidateResults([]*wire.DepositDataCLI{depositData}, ks, [][]*wire.SignedProof{proofs}, 1, owner, 0, withdraw)
+		require.NoError(t, err)
+		signedProofs := toSpecSignedProofs(proofs)
+		rMsg, err := clnt.ConstructResignMessage(
+			[]uint64{11, 22, 33, 44}, signedProofs[0].Proof.ValidatorPubKey, "mainnet",
+			eth1Creds(withdraw), owner, 10, uint64(spec_crypto.MIN_ACTIVATION_BALANCE), signedProofs,
+		)
+		require.NoError(t, err)
+		// the message keeps the owner that signs the batch, only the proofs name another
+		for _, proof := range rMsg.Proofs {
+			proof.Proof.Owner = otherOwner
+		}
+		rMsgs := []*wire.ResignMessage{rMsg}
+		_, _, _, err = executeResign(t, clnt, rMsgs, sk)
+		require.ErrorContains(t, err, string(wire.InitiatorErrorCodeCeremonyFailed))
 	})
 }

--- a/pkgs/dkg/drand.go
+++ b/pkgs/dkg/drand.go
@@ -588,6 +588,10 @@ func (o *LocalOwner) GetDKGNodes(ops []*spec.Operator) ([]kyber_dkg.Node, error)
 }
 
 func (o *LocalOwner) Resign(reqID [24]byte, r *wire.ResignMessage) (*wire.Transport, error) {
+	// sanity check of incoming proofs len
+	if len(r.Proofs) != len(r.Operators) {
+		return nil, fmt.Errorf("wrong proofs len at resign message: expected %d, got %d", len(r.Operators), len(r.Proofs))
+	}
 	position := -1
 	for i, op := range r.Operators {
 		if o.ID == op.ID {
@@ -598,7 +602,14 @@ func (o *LocalOwner) Resign(reqID [24]byte, r *wire.ResignMessage) (*wire.Transp
 	if position == -1 {
 		return nil, fmt.Errorf("operator not found among resign operators: %d", o.ID)
 	}
-	if err := spec.ValidateResignMessage(r.Resign, spec.GetOperator(r.Operators, o.ID), r.Proofs[position]); err != nil {
+	// the proof is validated against this operator's own key, not against the key
+	// supplied in the message
+	ownPubKey, err := spec_crypto.EncodeRSAPublicKey(&o.OperatorSecretKey.PublicKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode operator public key: %w", err)
+	}
+	self := &spec.Operator{ID: o.ID, PubKey: ownPubKey}
+	if err := spec.ValidateResignMessage(r.Resign, self, r.Proofs[position]); err != nil {
 		return nil, fmt.Errorf("failed to validate resign message: %w", err)
 	}
 	prShare, err := o.decryptFunc(r.Proofs[position].Proof.EncryptedShare)

--- a/pkgs/dkg/resign_regression_test.go
+++ b/pkgs/dkg/resign_regression_test.go
@@ -24,24 +24,30 @@ import (
 )
 
 // newTestOwner builds a LocalOwner exactly as the operator server would: it
-// decrypts ceremony shares with the operator's own RSA private key.
-func newTestOwner(t *testing.T, id uint64) (*LocalOwner, *rsa.PrivateKey) {
+// decrypts ceremony shares with the operator's own RSA private key. The returned
+// counter records how many times the share decryption ran, so tests can assert on
+// the behaviour itself rather than on the wording of the resulting error.
+func newTestOwner(t *testing.T, id uint64) (*LocalOwner, *rsa.PrivateKey, *int) {
 	t.Helper()
 	pv, _, err := spec_crypto.GenerateRSAKeys()
 	require.NoError(t, err)
 	logger, _ := zap.NewDevelopment()
+	decrypts := new(int)
 	o := &LocalOwner{
-		Logger:            logger.With(zap.Uint64("operator_id", id)),
-		ID:                id,
-		Suite:             kyber_bls.NewBLS12381Suite(),
-		exchanges:         make(map[uint64]*wire.Exchange),
-		signer:            crypto.RSASigner(pv),
-		decryptFunc:       func(ct []byte) ([]byte, error) { return spec_crypto.Decrypt(pv, ct) },
+		Logger:    logger.With(zap.Uint64("operator_id", id)),
+		ID:        id,
+		Suite:     kyber_bls.NewBLS12381Suite(),
+		exchanges: make(map[uint64]*wire.Exchange),
+		signer:    crypto.RSASigner(pv),
+		decryptFunc: func(ct []byte) ([]byte, error) {
+			*decrypts++
+			return spec_crypto.Decrypt(pv, ct)
+		},
 		OperatorSecretKey: pv,
 		done:              make(chan struct{}, 1),
 		startedDKG:        make(chan struct{}, 1),
 	}
-	return o, pv
+	return o, pv, decrypts
 }
 
 func encodePub(t *testing.T, pk *rsa.PublicKey) []byte {
@@ -74,7 +80,7 @@ func validWithdrawalCreds() []byte {
 // encrypted share is decrypted.
 func TestResignRejectsProofNotSignedByThisOperator(t *testing.T) {
 	opID := uint64(3)
-	op, opPriv := newTestOwner(t, opID)
+	op, opPriv, decrypts := newTestOwner(t, opID)
 
 	// A throwaway RSA keypair that is not this operator's key.
 	otherPriv, err := rsa.GenerateKey(rand.Reader, 2048)
@@ -134,10 +140,15 @@ func TestResignRejectsProofNotSignedByThisOperator(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorContains(t, err, "failed to validate resign message")
 	require.ErrorContains(t, err, "crypto/rsa: verification error")
+	require.ErrorIs(t, err, rsa.ErrVerification)
 	require.NotContains(t, err.Error(), "BLS secret key",
 		"validation must stop the request before the share is parsed")
 	require.NotContains(t, err.Error(), "decrypt",
 		"validation must stop the request before the share is decrypted")
+	// The assertions above only certify wording. This one certifies the behaviour:
+	// the chosen ciphertext was never fed to the operator's private key at all.
+	require.Zero(t, *decrypts,
+		"the share must not be decrypted when validation rejects the proof")
 }
 
 // TestResignErrorsAreIndistinguishableAcrossCiphertexts asserts that two resign
@@ -145,7 +156,7 @@ func TestResignRejectsProofNotSignedByThisOperator(t *testing.T) {
 // response carries no information about the ciphertext.
 func TestResignErrorsAreIndistinguishableAcrossCiphertexts(t *testing.T) {
 	opID := uint64(3)
-	op, opPriv := newTestOwner(t, opID)
+	op, opPriv, decrypts := newTestOwner(t, opID)
 
 	otherPriv, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err)
@@ -195,6 +206,11 @@ func TestResignErrorsAreIndistinguishableAcrossCiphertexts(t *testing.T) {
 	// The two ciphertexts are indistinguishable from the error alone.
 	require.Equal(t, errValid.Error(), errInvalid.Error(),
 		"errors must not vary with the supplied ciphertext")
+
+	// Indistinguishable errors would still leak through a timing side channel if the
+	// ciphertexts reached the private key at all. Neither did.
+	require.Zero(t, *decrypts,
+		"neither ciphertext may be decrypted when validation rejects the proof")
 }
 
 // TestResignRejectsProofOwnerMismatch asserts the ceremony-level check that the
@@ -202,7 +218,7 @@ func TestResignErrorsAreIndistinguishableAcrossCiphertexts(t *testing.T) {
 // key, so only the owner mismatch can reject it.
 func TestResignRejectsProofOwnerMismatch(t *testing.T) {
 	opID := uint64(3)
-	op, opPriv := newTestOwner(t, opID)
+	op, opPriv, _ := newTestOwner(t, opID)
 
 	proofOwner := common.HexToAddress("0x00000000000000000000000000000000000000aa")
 	resignOwner := common.HexToAddress("0x00000000000000000000000000000000000000bb")
@@ -240,7 +256,7 @@ func TestResignRejectsProofOwnerMismatch(t *testing.T) {
 // and operators lists disagree, rather than indexing out of range.
 func TestResignRejectsProofsLenMismatch(t *testing.T) {
 	opID := uint64(3)
-	op, opPriv := newTestOwner(t, opID)
+	op, opPriv, _ := newTestOwner(t, opID)
 
 	tests := []struct {
 		name   string

--- a/pkgs/dkg/resign_regression_test.go
+++ b/pkgs/dkg/resign_regression_test.go
@@ -1,0 +1,276 @@
+package dkg
+
+// Regression tests for LocalOwner.Resign proof validation.
+//
+// The invariant under test: a resign ceremony proof is validated against this
+// operator's OWN RSA key, never against a key supplied in the message, and the
+// encrypted share is only decrypted after that validation succeeds.
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"errors"
+	"testing"
+
+	kyber_bls "github.com/drand/kyber-bls12381"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	spec "github.com/ssvlabs/dkg-spec"
+	spec_crypto "github.com/ssvlabs/dkg-spec/crypto"
+	"github.com/ssvlabs/ssv-dkg/pkgs/crypto"
+	"github.com/ssvlabs/ssv-dkg/pkgs/wire"
+)
+
+// newTestOwner builds a LocalOwner exactly as the operator server would: it
+// decrypts ceremony shares with the operator's own RSA private key.
+func newTestOwner(t *testing.T, id uint64) (*LocalOwner, *rsa.PrivateKey) {
+	t.Helper()
+	pv, _, err := spec_crypto.GenerateRSAKeys()
+	require.NoError(t, err)
+	logger, _ := zap.NewDevelopment()
+	o := &LocalOwner{
+		Logger:            logger.With(zap.Uint64("operator_id", id)),
+		ID:                id,
+		Suite:             kyber_bls.NewBLS12381Suite(),
+		exchanges:         make(map[uint64]*wire.Exchange),
+		signer:            crypto.RSASigner(pv),
+		decryptFunc:       func(ct []byte) ([]byte, error) { return spec_crypto.Decrypt(pv, ct) },
+		OperatorSecretKey: pv,
+		done:              make(chan struct{}, 1),
+		startedDKG:        make(chan struct{}, 1),
+	}
+	return o, pv
+}
+
+func encodePub(t *testing.T, pk *rsa.PublicKey) []byte {
+	t.Helper()
+	b, err := spec_crypto.EncodeRSAPublicKey(pk)
+	require.NoError(t, err)
+	return b
+}
+
+// signProof RSA-signs a Proof with the given key, producing a SignedProof that
+// validates against that key's public half.
+func signProof(t *testing.T, sk *rsa.PrivateKey, p *spec.Proof) *spec.SignedProof {
+	t.Helper()
+	root, err := p.HashTreeRoot()
+	require.NoError(t, err)
+	sig, err := spec_crypto.SignRSA(sk, root[:])
+	require.NoError(t, err)
+	return &spec.SignedProof{Proof: p, Signature: sig}
+}
+
+func validWithdrawalCreds() []byte {
+	creds := make([]byte, 32)
+	creds[0] = 1 // ETH1WithdrawalPrefix
+	return creds
+}
+
+// TestResignRejectsProofNotSignedByThisOperator asserts that a proof signed by a
+// key other than the operator's own is rejected, even when the message lists this
+// operator's ID twice with the foreign key first. Validation must fail before the
+// encrypted share is decrypted.
+func TestResignRejectsProofNotSignedByThisOperator(t *testing.T) {
+	opID := uint64(3)
+	op, opPriv := newTestOwner(t, opID)
+
+	// A throwaway RSA keypair that is not this operator's key.
+	otherPriv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	otherAddr := common.HexToAddress("0x00000000000000000000000000000000deadbeef")
+	validatorPK := make([]byte, 48)
+	for i := range validatorPK {
+		validatorPK[i] = 0xAB
+	}
+
+	// A chosen ciphertext, encrypted under the operator's public key so PKCS#1 v1.5
+	// padding validates. Its plaintext is not a BLS secret key.
+	chosenCiphertext, err := rsa.EncryptPKCS1v15(rand.Reader, &opPriv.PublicKey, []byte("not-a-bls-key"))
+	require.NoError(t, err)
+
+	proof := &spec.Proof{
+		ValidatorPubKey: validatorPK,
+		EncryptedShare:  chosenCiphertext,
+		SharePubKey:     make([]byte, 48),
+		Owner:           otherAddr,
+	}
+	signed := signProof(t, otherPriv, proof) // signed with the foreign key
+
+	resign := &spec.Resign{
+		ValidatorPubKey:       validatorPK,
+		Fork:                  [4]byte{0, 0, 0, 0},
+		WithdrawalCredentials: validWithdrawalCreds(),
+		Owner:                 otherAddr,
+		Nonce:                 0,
+		Amount:                32000000000, // 32 ETH, MIN_ACTIVATION_BALANCE
+	}
+
+	// The operator's ID appears TWICE, the foreign key first.
+	msg := &wire.ResignMessage{
+		Operators: []*spec.Operator{
+			{ID: opID, PubKey: encodePub(t, &otherPriv.PublicKey)}, // entry carrying a different key
+			{ID: opID, PubKey: encodePub(t, &opPriv.PublicKey)},    // genuine
+		},
+		Resign: resign,
+		Proofs: []*spec.SignedProof{signed, signed},
+	}
+
+	// Documents why the operator entry in the message cannot be trusted: validated
+	// against the message-supplied key, the proof passes.
+	err = spec.ValidateResignMessage(resign, spec.GetOperator(msg.Operators, opID), msg.Proofs[0])
+	require.NoError(t, err, "the message-supplied key accepts the proof")
+
+	// Validated against the operator's own key — the key the fixed code uses — it fails.
+	selfOp := &spec.Operator{ID: opID, PubKey: encodePub(t, &opPriv.PublicKey)}
+	err = spec.ValidateResignMessage(resign, selfOp, msg.Proofs[0])
+	require.Error(t, err, "validating against the operator's own key rejects the proof")
+
+	// End to end: Resign rejects at validation and never decrypts the share.
+	reqID := [24]byte{1, 2, 3}
+	_, err = op.Resign(reqID, msg)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "failed to validate resign message")
+	require.ErrorContains(t, err, "crypto/rsa: verification error")
+	require.NotContains(t, err.Error(), "BLS secret key",
+		"validation must stop the request before the share is parsed")
+	require.NotContains(t, err.Error(), "decrypt",
+		"validation must stop the request before the share is decrypted")
+}
+
+// TestResignErrorsAreIndistinguishableAcrossCiphertexts asserts that two resign
+// requests differing only in their encrypted share produce the same error, so the
+// response carries no information about the ciphertext.
+func TestResignErrorsAreIndistinguishableAcrossCiphertexts(t *testing.T) {
+	opID := uint64(3)
+	op, opPriv := newTestOwner(t, opID)
+
+	otherPriv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	otherAddr := common.HexToAddress("0x00000000000000000000000000000000deadbeef")
+	validatorPK := make([]byte, 48)
+
+	buildResign := func(ciphertext []byte) *wire.ResignMessage {
+		proof := &spec.Proof{
+			ValidatorPubKey: validatorPK,
+			EncryptedShare:  ciphertext,
+			SharePubKey:     make([]byte, 48),
+			Owner:           otherAddr,
+		}
+		signed := signProof(t, otherPriv, proof)
+		return &wire.ResignMessage{
+			Operators: []*spec.Operator{{ID: opID, PubKey: encodePub(t, &otherPriv.PublicKey)}},
+			Resign: &spec.Resign{
+				ValidatorPubKey:       validatorPK,
+				WithdrawalCredentials: validWithdrawalCreds(),
+				Owner:                 otherAddr,
+				Amount:                32000000000,
+			},
+			Proofs: []*spec.SignedProof{signed},
+		}
+	}
+
+	// Well-formed PKCS#1 v1.5 padding.
+	validPadding, err := rsa.EncryptPKCS1v15(rand.Reader, &opPriv.PublicKey, []byte("x"))
+	require.NoError(t, err)
+	_, errValid := op.Resign([24]byte{}, buildResign(validPadding))
+	require.Error(t, errValid)
+
+	// Malformed padding.
+	invalidPadding := make([]byte, 256)
+	for i := range invalidPadding {
+		invalidPadding[i] = 0xFF
+	}
+	_, errInvalid := op.Resign([24]byte{}, buildResign(invalidPadding))
+	require.Error(t, errInvalid)
+
+	// Both stop at validation, so neither reaches decryption.
+	require.ErrorContains(t, errValid, "failed to validate resign message")
+	require.ErrorContains(t, errInvalid, "failed to validate resign message")
+	require.False(t, errors.Is(errValid, rsa.ErrDecryption))
+	require.False(t, errors.Is(errInvalid, rsa.ErrDecryption))
+
+	// The two ciphertexts are indistinguishable from the error alone.
+	require.Equal(t, errValid.Error(), errInvalid.Error(),
+		"errors must not vary with the supplied ciphertext")
+}
+
+// TestResignRejectsProofOwnerMismatch asserts the ceremony-level check that the
+// resign owner matches the proof owner. The proof is signed by this operator's own
+// key, so only the owner mismatch can reject it.
+func TestResignRejectsProofOwnerMismatch(t *testing.T) {
+	opID := uint64(3)
+	op, opPriv := newTestOwner(t, opID)
+
+	proofOwner := common.HexToAddress("0x00000000000000000000000000000000000000aa")
+	resignOwner := common.HexToAddress("0x00000000000000000000000000000000000000bb")
+	validatorPK := make([]byte, 48)
+	for i := range validatorPK {
+		validatorPK[i] = 0xCD
+	}
+
+	proof := &spec.Proof{
+		ValidatorPubKey: validatorPK,
+		EncryptedShare:  make([]byte, 256),
+		SharePubKey:     make([]byte, 48),
+		Owner:           proofOwner,
+	}
+	signed := signProof(t, opPriv, proof) // genuine: signed with the operator's own key
+
+	msg := &wire.ResignMessage{
+		Operators: []*spec.Operator{{ID: opID, PubKey: encodePub(t, &opPriv.PublicKey)}},
+		Resign: &spec.Resign{
+			ValidatorPubKey:       validatorPK,
+			WithdrawalCredentials: validWithdrawalCreds(),
+			Owner:                 resignOwner,
+			Amount:                32000000000,
+		},
+		Proofs: []*spec.SignedProof{signed},
+	}
+
+	_, err := op.Resign([24]byte{}, msg)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "failed to validate resign message")
+	require.ErrorContains(t, err, "invalid owner address")
+}
+
+// TestResignRejectsProofsLenMismatch asserts the message is rejected when the proofs
+// and operators lists disagree, rather than indexing out of range.
+func TestResignRejectsProofsLenMismatch(t *testing.T) {
+	opID := uint64(3)
+	op, opPriv := newTestOwner(t, opID)
+
+	tests := []struct {
+		name   string
+		proofs []*spec.SignedProof
+	}{
+		{name: "no proofs", proofs: nil},
+		{
+			name:   "fewer proofs than operators",
+			proofs: []*spec.SignedProof{{Proof: &spec.Proof{}, Signature: make([]byte, 256)}},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			msg := &wire.ResignMessage{
+				Operators: []*spec.Operator{
+					{ID: opID, PubKey: encodePub(t, &opPriv.PublicKey)},
+					{ID: opID + 1, PubKey: encodePub(t, &opPriv.PublicKey)},
+				},
+				Resign: &spec.Resign{
+					ValidatorPubKey:       make([]byte, 48),
+					WithdrawalCredentials: validWithdrawalCreds(),
+					Owner:                 common.HexToAddress("0x00000000000000000000000000000000000000aa"),
+					Amount:                32000000000,
+				},
+				Proofs: tc.proofs,
+			}
+
+			_, err := op.Resign([24]byte{}, msg)
+			require.ErrorContains(t, err, "wrong proofs len at resign message")
+		})
+	}
+}

--- a/pkgs/initiator/requests.go
+++ b/pkgs/initiator/requests.go
@@ -36,7 +36,7 @@ func (c *Initiator) SendAndCollect(op wire.OperatorCLI, method string, data []by
 		if err != nil {
 			return nil, fmt.Errorf("cant parse error message: %w", err)
 		}
-		return nil, fmt.Errorf("operator %d failed with: probably of old version, please upgrade %w", op.ID, errors.New(errString))
+		return nil, fmt.Errorf("operator %d failed: %w", op.ID, errors.New(errString))
 	}
 	return resdata, nil
 }

--- a/pkgs/initiator/requests_test.go
+++ b/pkgs/initiator/requests_test.go
@@ -1,0 +1,74 @@
+package initiator_test
+
+// Regression tests for how operator responses are presented to the user.
+//
+// The invariant under test: an error an operator actually reported is passed on as itself,
+// without a diagnosis the initiator is in no position to make.
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/imroc/req/v3"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/ssvlabs/ssv-dkg/pkgs/initiator"
+	"github.com/ssvlabs/ssv-dkg/pkgs/wire"
+)
+
+// failingOperator serves one wire-encoded error at the given status for every request.
+func failingOperator(t *testing.T, status int, body []byte) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.WriteHeader(status)
+		_, err := writer.Write(body)
+		require.NoError(t, err)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestSendAndCollectDoesNotBlameOperatorVersion asserts a ceremony failure an operator
+// deliberately reported is not re-labelled as a version problem.
+//
+// The ceremony routes answer failures with a fixed code that carries no detail. Prefixing
+// that with an upgrade instruction leaves the operator reading a message whose only
+// actionable-looking words are a diagnosis nothing supports — and sends them to check
+// versions while the real cause, usually an authorisation failure, goes unexamined.
+func TestSendAndCollectDoesNotBlameOperatorVersion(t *testing.T) {
+	ceremonyFailed := wire.MakeErr(errors.New(string(wire.InitiatorErrorCodeCeremonyFailed)))
+	srv := failingOperator(t, http.StatusBadRequest, ceremonyFailed)
+
+	c := &initiator.Initiator{Logger: zap.NewNop(), Client: req.C()}
+	op := wire.OperatorCLI{Addr: srv.URL, ID: 11}
+
+	_, err := c.SendAndCollect(op, "resign", []byte("request"))
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "operator 11 failed",
+		"the operator that failed must still be named")
+	require.ErrorContains(t, err, string(wire.InitiatorErrorCodeCeremonyFailed),
+		"the error the operator reported must be passed on as it was")
+	require.NotContains(t, err.Error(), "upgrade",
+		"a reported ceremony failure is not evidence of a version problem")
+	require.NotContains(t, err.Error(), "old version")
+}
+
+// TestGetAndCollectStillFlagsUnparseableResponses is the counterpart: on a GET route, a
+// body that cannot be decoded as a wire error IS evidence the remote speaks a different
+// protocol, and that is the one case where suggesting an upgrade is warranted.
+func TestGetAndCollectStillFlagsUnparseableResponses(t *testing.T) {
+	srv := failingOperator(t, http.StatusBadRequest, []byte("not an ssz-encoded error"))
+
+	c := &initiator.Initiator{Logger: zap.NewNop(), Client: req.C()}
+	op := wire.OperatorCLI{Addr: srv.URL, ID: 11}
+
+	_, err := c.GetAndCollect(op, "health_check")
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "please upgrade",
+		"an undecodable response is the case an upgrade hint belongs to")
+}

--- a/pkgs/operator/handlers.go
+++ b/pkgs/operator/handlers.go
@@ -33,6 +33,23 @@ func maskCeremonyError(err error) error {
 	return &utils.SensitiveError{Err: err, PresentedErr: string(wire.InitiatorErrorCodeCeremonyFailed)}
 }
 
+// ceremonyResponseError decides what the initiator is told when a ceremony operation
+// fails. Everything is masked to the generic ceremony code, with a single carve-out: a
+// version mismatch is reported verbatim. Exact version equality between initiator and
+// operators is a protocol invariant, the check runs before any ceremony material is
+// unmarshalled, and its message carries only the two version strings — masking it would
+// hide the most likely upgrade failure behind an undiagnosable code.
+//
+// ceremonyErr is the error as returned by HandleInstanceOperation and is what the
+// carve-out matches on; respErr is the operator-prefixed error presented for every other
+// failure, unchanged from before this carve-out existed.
+func ceremonyResponseError(ceremonyErr, respErr error) error {
+	if errors.Is(ceremonyErr, ErrVersionMismatch) {
+		return ceremonyErr
+	}
+	return maskCeremonyError(respErr)
+}
+
 func (s *Server) resultsHandler(writer http.ResponseWriter, request *http.Request) {
 	signedResultMsg, err := processIncomingRequest(writer, request, wire.ResultMessageType, s.State.OperatorID)
 	if err != nil {
@@ -134,7 +151,7 @@ func (s *Server) signedResignHandler(writer http.ResponseWriter, request *http.R
 	if err != nil {
 		logger.Error("error resigning instance", zap.Error(err))
 		respErr := fmt.Errorf("operator %d, failed to resign, err: %w", s.State.OperatorID, err)
-		utils.WriteErrorResponse(s.Logger, writer, maskCeremonyError(respErr), http.StatusBadRequest)
+		utils.WriteErrorResponse(s.Logger, writer, ceremonyResponseError(err, respErr), http.StatusBadRequest)
 		return
 	}
 	logger.Info("✅ resigned data successfully")
@@ -163,7 +180,7 @@ func (s *Server) signedReshareHandler(writer http.ResponseWriter, request *http.
 	if err != nil {
 		logger.Error("error resharing instance", zap.Error(err))
 		respErr := fmt.Errorf("operator %d, err: %w", s.State.OperatorID, err)
-		utils.WriteErrorResponse(s.Logger, writer, maskCeremonyError(respErr), http.StatusBadRequest)
+		utils.WriteErrorResponse(s.Logger, writer, ceremonyResponseError(err, respErr), http.StatusBadRequest)
 		return
 	}
 	logger.Info("✅ Reshare instance created successfully")

--- a/pkgs/operator/handlers.go
+++ b/pkgs/operator/handlers.go
@@ -27,7 +27,9 @@ func sanitizeCeremonyError(err error) error {
 	return err
 }
 
-func sanitizeReshareError(err error) error {
+// maskCeremonyError hides ceremony failure detail from the initiator on the routes
+// that decrypt ceremony material. The full error is still logged locally.
+func maskCeremonyError(err error) error {
 	return &utils.SensitiveError{Err: err, PresentedErr: string(wire.InitiatorErrorCodeCeremonyFailed)}
 }
 
@@ -132,7 +134,7 @@ func (s *Server) signedResignHandler(writer http.ResponseWriter, request *http.R
 	if err != nil {
 		logger.Error("error resigning instance", zap.Error(err))
 		respErr := fmt.Errorf("operator %d, failed to resign, err: %w", s.State.OperatorID, err)
-		utils.WriteErrorResponse(s.Logger, writer, sanitizeCeremonyError(respErr), http.StatusBadRequest)
+		utils.WriteErrorResponse(s.Logger, writer, maskCeremonyError(respErr), http.StatusBadRequest)
 		return
 	}
 	logger.Info("✅ resigned data successfully")
@@ -161,7 +163,7 @@ func (s *Server) signedReshareHandler(writer http.ResponseWriter, request *http.
 	if err != nil {
 		logger.Error("error resharing instance", zap.Error(err))
 		respErr := fmt.Errorf("operator %d, err: %w", s.State.OperatorID, err)
-		utils.WriteErrorResponse(s.Logger, writer, sanitizeReshareError(respErr), http.StatusBadRequest)
+		utils.WriteErrorResponse(s.Logger, writer, maskCeremonyError(respErr), http.StatusBadRequest)
 		return
 	}
 	logger.Info("✅ Reshare instance created successfully")

--- a/pkgs/operator/instances_manager.go
+++ b/pkgs/operator/instances_manager.go
@@ -158,7 +158,10 @@ var ErrVersionMismatch = errors.New("wrong version")
 // HandleInstanceOperation handles both Resign and Reshare operations.
 func (s *Switch) HandleInstanceOperation(reqID [24]byte, transportMsg *wire.Transport, initiatorPub, initiatorSignature []byte, operationType string) ([][]byte, error) {
 	if !bytes.Equal(transportMsg.Version, s.Version) {
-		return nil, fmt.Errorf("%w: remote %s local %s", ErrVersionMismatch, transportMsg.Version, s.Version)
+		// The remote version is attacker-controlled and this error is returned unmasked,
+		// so it is not echoed back: raw bytes would reach the response body and the
+		// operator's console log. The initiator already knows what it sent.
+		return nil, fmt.Errorf("%w: operator runs %s", ErrVersionMismatch, s.Version)
 	}
 
 	// Check that incoming message signature is valid

--- a/pkgs/operator/instances_manager.go
+++ b/pkgs/operator/instances_manager.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/rsa"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"time"
 
@@ -148,10 +149,16 @@ func (s *Switch) cleanInstances() int {
 	return count
 }
 
+// ErrVersionMismatch reports that the initiator and this operator run different protocol
+// versions. Exact version equality is a protocol invariant, so this is the one ceremony
+// failure reported to the initiator verbatim: it is raised before any ceremony material is
+// unmarshalled and its message carries no ceremony data.
+var ErrVersionMismatch = errors.New("wrong version")
+
 // HandleInstanceOperation handles both Resign and Reshare operations.
 func (s *Switch) HandleInstanceOperation(reqID [24]byte, transportMsg *wire.Transport, initiatorPub, initiatorSignature []byte, operationType string) ([][]byte, error) {
 	if !bytes.Equal(transportMsg.Version, s.Version) {
-		return nil, fmt.Errorf("wrong version: remote %s local %s", transportMsg.Version, s.Version)
+		return nil, fmt.Errorf("%w: remote %s local %s", ErrVersionMismatch, transportMsg.Version, s.Version)
 	}
 
 	// Check that incoming message signature is valid

--- a/pkgs/operator/instances_manager.go
+++ b/pkgs/operator/instances_manager.go
@@ -170,15 +170,15 @@ func (s *Switch) HandleInstanceOperation(reqID [24]byte, transportMsg *wire.Tran
 
 	s.Logger.Info(fmt.Sprintf("🚀 Handling %s operation", operationType))
 
-	var allOps []*spec.Operator
-
 	switch operationType {
 	case "resign":
 		signedResign := &wire.SignedResign{}
 		if err := signedResign.UnmarshalSSZ(transportMsg.Data); err != nil {
 			return nil, fmt.Errorf("failed to ssz unmarshal message: probably an upgrade to latest version needed: %w", err)
 		}
-		allOps = signedResign.Messages[0].Operators
+		if len(signedResign.Messages) == 0 {
+			return nil, fmt.Errorf("%s: no resign messages", operationType)
+		}
 		hexString, err := utils.GetMessageString(signedResign.Messages)
 		if err != nil {
 			return nil, err
@@ -190,6 +190,9 @@ func (s *Switch) HandleInstanceOperation(reqID [24]byte, transportMsg *wire.Tran
 			zap.String("resign message hash", hexString),
 			zap.String("EIP1271 owner signature", hex.EncodeToString(signedResign.Signature)))
 
+		// the batch is authorised by a single owner signature; that owner is the one
+		// the signature is verified against
+		owner := signedResign.Messages[0].Resign.Owner
 		// verify EIP1271 signature
 		hash, err := utils.GetMessageHash(signedResign.Messages)
 		if err != nil {
@@ -197,7 +200,7 @@ func (s *Switch) HandleInstanceOperation(reqID [24]byte, transportMsg *wire.Tran
 		}
 		if err := spec_crypto.VerifySignedMessageByOwner(
 			s.EthClient,
-			signedResign.Messages[0].Proofs[0].Proof.Owner,
+			owner,
 			hash,
 			signedResign.Signature,
 		); err != nil {
@@ -206,10 +209,17 @@ func (s *Switch) HandleInstanceOperation(reqID [24]byte, transportMsg *wire.Tran
 
 		s.Logger.Info(fmt.Sprintf("✅ %s eip1271 owner signature is successfully verified", operationType), zap.String("from initiator", fmt.Sprintf("%x", initiatorPubKey.N.Bytes())))
 
+		// every message in the batch must belong to the authorised owner
+		for i, instance := range signedResign.Messages {
+			if err := checkBatchMessageOwner(owner, instance.Resign.Owner, instance.Proofs, i); err != nil {
+				return nil, fmt.Errorf("%s: %w", operationType, err)
+			}
+		}
+
 		resps := [][]byte{}
 		// Run all resign/reshare ceremonies
 		for _, instance := range signedResign.Messages {
-			resp, err := s.runInstance(reqID, instance, allOps, initiatorPubKey, operationType)
+			resp, err := s.runInstance(reqID, instance, instance.Operators, initiatorPubKey, operationType)
 			if err != nil {
 				return nil, fmt.Errorf("%s: failed to run instance: %w", operationType, err)
 			}
@@ -226,8 +236,6 @@ func (s *Switch) HandleInstanceOperation(reqID [24]byte, transportMsg *wire.Tran
 		if len(signedReshare.Messages) == 0 {
 			return nil, fmt.Errorf("%s: no reshare messages", operationType)
 		}
-		allOps = append(allOps, signedReshare.Messages[0].Reshare.OldOperators...)
-		allOps = append(allOps, signedReshare.Messages[0].Reshare.NewOperators...)
 		hexString, err := utils.GetMessageString(signedReshare.Messages)
 		if err != nil {
 			return nil, err
@@ -241,6 +249,9 @@ func (s *Switch) HandleInstanceOperation(reqID [24]byte, transportMsg *wire.Tran
 			zap.String("reshare message hash", hexString),
 			zap.String("EIP1271 owner signature", hex.EncodeToString(signedReshare.Signature)))
 
+		// the batch is authorised by a single owner signature; that owner is the one
+		// the signature is verified against
+		owner := signedReshare.Messages[0].Reshare.Owner
 		// verify EIP1271 signature
 		hash, err := utils.GetMessageHash(signedReshare.Messages)
 		if err != nil {
@@ -248,7 +259,7 @@ func (s *Switch) HandleInstanceOperation(reqID [24]byte, transportMsg *wire.Tran
 		}
 		if err := spec_crypto.VerifySignedMessageByOwner(
 			s.EthClient,
-			signedReshare.Messages[0].Proofs[0].Proof.Owner,
+			owner,
 			hash,
 			signedReshare.Signature,
 		); err != nil {
@@ -257,9 +268,19 @@ func (s *Switch) HandleInstanceOperation(reqID [24]byte, transportMsg *wire.Tran
 
 		s.Logger.Info(fmt.Sprintf("✅ %s eip1271 owner signature is successfully verified", operationType), zap.String("from initiator", fmt.Sprintf("%x", initiatorPubKey.N.Bytes())))
 
+		// every message in the batch must belong to the authorised owner
+		for i, instance := range signedReshare.Messages {
+			if err := checkBatchMessageOwner(owner, instance.Reshare.Owner, instance.Proofs, i); err != nil {
+				return nil, fmt.Errorf("%s: %w", operationType, err)
+			}
+		}
+
 		resps := [][]byte{}
 		// Run all resign/reshare ceremonies
 		for _, instance := range signedReshare.Messages {
+			var allOps []*spec.Operator
+			allOps = append(allOps, instance.Reshare.OldOperators...)
+			allOps = append(allOps, instance.Reshare.NewOperators...)
 			resp, err := s.runInstance(reqID, instance, allOps, initiatorPubKey, operationType)
 			if err != nil {
 				return nil, fmt.Errorf("%s: failed to run instance: %w", operationType, err)
@@ -272,6 +293,23 @@ func (s *Switch) HandleInstanceOperation(reqID [24]byte, transportMsg *wire.Tran
 	default:
 		return nil, fmt.Errorf("unknown operation type: %s", operationType)
 	}
+}
+
+// checkBatchMessageOwner verifies that a batch message and every proof it carries
+// belong to the owner that authorised the batch.
+func checkBatchMessageOwner(authorised, msgOwner [20]byte, proofs []*spec.SignedProof, index int) error {
+	if msgOwner != authorised {
+		return fmt.Errorf("message %d owner %x is not the authorised owner %x", index, msgOwner, authorised)
+	}
+	if len(proofs) == 0 {
+		return fmt.Errorf("message %d has no proofs", index)
+	}
+	for j, proof := range proofs {
+		if proof.Proof.Owner != authorised {
+			return fmt.Errorf("message %d proof %d owner %x is not the authorised owner %x", index, j, proof.Proof.Owner, authorised)
+		}
+	}
+	return nil
 }
 
 // Helper functions to abstract out common behavior

--- a/pkgs/operator/instances_manager_regression_test.go
+++ b/pkgs/operator/instances_manager_regression_test.go
@@ -11,11 +11,13 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"errors"
+	"fmt"
 	"math/big"
 	"testing"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/herumi/bls-eth-go-binary/bls"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
@@ -65,6 +67,7 @@ var otherOwner = common.HexToAddress("0x000000000000000000000000000000000C71c71c
 type batchTestEnv struct {
 	swtch   *Switch
 	opID    uint64
+	opPriv  *rsa.PrivateKey
 	opPub   []byte
 	version []byte
 	queried *[]common.Address
@@ -97,6 +100,7 @@ func newBatchTestEnv(t *testing.T) *batchTestEnv {
 	return &batchTestEnv{
 		swtch:   NewSwitch(opPriv, logger, version, opPub, opID, eth),
 		opID:    opID,
+		opPriv:  opPriv,
 		opPub:   opPub,
 		version: version,
 		queried: queried,
@@ -109,13 +113,19 @@ func (e *batchTestEnv) operators() []*spec.Operator {
 	return []*spec.Operator{{ID: e.opID, PubKey: e.opPub}}
 }
 
+// mustRSAKey returns a fresh RSA private key.
+func mustRSAKey(t *testing.T) *rsa.PrivateKey {
+	t.Helper()
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	return priv
+}
+
 // foreignOperatorKey returns an encoded RSA public key belonging to no test node,
 // so operator lookups by public key never resolve to it.
 func foreignOperatorKey(t *testing.T) []byte {
 	t.Helper()
-	priv, err := rsa.GenerateKey(rand.Reader, 2048)
-	require.NoError(t, err)
-	pub, err := spec_crypto.EncodeRSAPublicKey(&priv.PublicKey)
+	pub, err := spec_crypto.EncodeRSAPublicKey(&mustRSAKey(t).PublicKey)
 	require.NoError(t, err)
 	return pub
 }
@@ -145,7 +155,19 @@ func (e *batchTestEnv) resignMessage(owner common.Address, validatorPK []byte, p
 	}
 }
 
-func (e *batchTestEnv) reshareMessage(owner common.Address, validatorPK []byte) *wire.ReshareMessage {
+func (e *batchTestEnv) reshareMessage(owner common.Address, validatorPK []byte, proofOwners ...common.Address) *wire.ReshareMessage {
+	if len(proofOwners) == 0 {
+		proofOwners = []common.Address{owner}
+	}
+	proofs := make([]*spec.SignedProof, 0, len(proofOwners))
+	for _, proofOwner := range proofOwners {
+		proofs = append(proofs, &spec.SignedProof{Proof: &spec.Proof{
+			ValidatorPubKey: validatorPK,
+			EncryptedShare:  bytesRepeat(0x01, 128),
+			SharePubKey:     bytesRepeat(0x00, 48),
+			Owner:           proofOwner,
+		}, Signature: bytesRepeat(0x00, 256)})
+	}
 	return &wire.ReshareMessage{
 		Reshare: &spec.Reshare{
 			ValidatorPubKey:       validatorPK,
@@ -157,12 +179,98 @@ func (e *batchTestEnv) reshareMessage(owner common.Address, validatorPK []byte) 
 			Owner:                 owner,
 			Amount:                uint64(spec_crypto.MIN_ACTIVATION_BALANCE),
 		},
-		Proofs: []*spec.SignedProof{{Proof: &spec.Proof{
+		Proofs: proofs,
+	}
+}
+
+// foreignOperators returns an ordered operator list whose keys belong to no test node.
+func foreignOperators(t *testing.T, ids ...uint64) []*spec.Operator {
+	t.Helper()
+	ops := make([]*spec.Operator, 0, len(ids))
+	for _, id := range ids {
+		ops = append(ops, &spec.Operator{ID: id, PubKey: foreignOperatorKey(t)})
+	}
+	return ops
+}
+
+// blsSharePubKey returns a well-formed BLS public key, so proofs carrying it survive the
+// commitment recovery that precedes any ownership check.
+func blsSharePubKey(t *testing.T) []byte {
+	t.Helper()
+	sk := &bls.SecretKey{}
+	sk.SetByCSPRNG()
+	return sk.GetPublicKey().Serialize()
+}
+
+// validResignMessage builds a resign message that runs to completion: the proof is signed
+// by this node's own RSA key and its encrypted share really is a BLS secret key encrypted
+// to this node. Tests that must observe whether a ceremony ran need a message that can
+// actually run — a message rejected on its own merits makes "no instance was created"
+// true whether or not the guard under test exists.
+func (e *batchTestEnv) validResignMessage(t *testing.T, owner common.Address, validatorPK []byte) *wire.ResignMessage {
+	t.Helper()
+	share := &bls.SecretKey{}
+	share.SetByCSPRNG()
+	encryptedShare, err := spec_crypto.Encrypt(&e.opPriv.PublicKey, []byte(share.SerializeToHexStr()))
+	require.NoError(t, err)
+
+	proof := &spec.Proof{
+		ValidatorPubKey: validatorPK,
+		EncryptedShare:  encryptedShare,
+		SharePubKey:     share.GetPublicKey().Serialize(),
+		Owner:           owner,
+	}
+	root, err := proof.HashTreeRoot()
+	require.NoError(t, err)
+	signature, err := spec_crypto.SignRSA(e.opPriv, root[:])
+	require.NoError(t, err)
+
+	return &wire.ResignMessage{
+		Operators: e.operators(),
+		Resign: &spec.Resign{
+			ValidatorPubKey:       validatorPK,
+			Fork:                  [4]byte{0, 0, 0, 0}, // mainnet
+			WithdrawalCredentials: eth1Creds(),
+			Owner:                 owner,
+			Amount:                uint64(spec_crypto.MIN_ACTIVATION_BALANCE),
+		},
+		Proofs: []*spec.SignedProof{{Proof: proof, Signature: signature}},
+	}
+}
+
+// validReshareMessage builds a reshare message that runs to completion with this node
+// among the NEW operators only. On that path getPublicCommitsAndSecretShare never enters
+// its old-operator branch, so no proof of ours is validated and no share of ours is
+// decrypted — only the membership-independent structural checks stand between the message
+// and a created instance. That is the path the disclosed fix hardened, and it lets a test
+// observe whether a guard ran by asking whether an instance exists.
+func (e *batchTestEnv) validReshareMessage(t *testing.T, owner common.Address, validatorPK []byte) *wire.ReshareMessage {
+	t.Helper()
+	oldOperators := foreignOperators(t, 10, 20, 30, 40)
+	newOperators := append([]*spec.Operator{{ID: e.opID, PubKey: e.opPub}}, foreignOperators(t, 2, 3, 4)...)
+
+	proofs := make([]*spec.SignedProof, 0, len(oldOperators))
+	for range oldOperators {
+		proofs = append(proofs, &spec.SignedProof{Proof: &spec.Proof{
 			ValidatorPubKey: validatorPK,
 			EncryptedShare:  bytesRepeat(0x01, 128),
-			SharePubKey:     bytesRepeat(0x00, 48),
+			SharePubKey:     blsSharePubKey(t),
 			Owner:           owner,
-		}, Signature: bytesRepeat(0x00, 256)}},
+		}, Signature: bytesRepeat(0x00, 256)})
+	}
+
+	return &wire.ReshareMessage{
+		Reshare: &spec.Reshare{
+			ValidatorPubKey:       validatorPK,
+			OldOperators:          oldOperators,
+			NewOperators:          newOperators,
+			OldT:                  3,
+			NewT:                  3,
+			WithdrawalCredentials: eth1Creds(),
+			Owner:                 owner,
+			Amount:                uint64(spec_crypto.MIN_ACTIVATION_BALANCE),
+		},
+		Proofs: proofs,
 	}
 }
 
@@ -237,6 +345,34 @@ func TestResignBatchRejectsProofOwnerMismatch(t *testing.T) {
 	require.Empty(t, env.swtch.Instances)
 }
 
+// TestResignBatchRejectsMessageOwnerWhenProofsLookAuthorised asserts that a message
+// whose own owner is not the authorised one is rejected even when all of its proofs name
+// the authorised owner, so the proof loop cannot stand in for the message-owner check.
+//
+// Message 0 is a ceremony that would run to completion. That is what gives this test
+// teeth: the batch must be rejected before ANY message executes, so the absence of an
+// instance is evidence the guard ran, not an accident of a fixture that could never run.
+func TestResignBatchRejectsMessageOwnerWhenProofsLookAuthorised(t *testing.T) {
+	env := newBatchTestEnv(t)
+
+	signedResign := &wire.SignedResign{
+		Messages: []*wire.ResignMessage{
+			env.validResignMessage(t, contractOwner, bytesRepeat(0xAA, 48)), // would complete
+			// message owner is not the authorised owner, but its proofs claim to be
+			env.resignMessage(otherOwner, bytesRepeat(0xBB, 48), contractOwner),
+		},
+		Signature: bytesRepeat(0x00, 65),
+	}
+
+	_, err := env.handle(t, signedResign, wire.SignedResignMessageType, "resign")
+
+	require.Error(t, err)
+	require.Empty(t, env.swtch.Instances,
+		"the batch must be rejected before any ceremony runs, including the one that would succeed")
+	require.ErrorContains(t, err, "message 1 owner")
+	require.ErrorContains(t, err, "is not the authorised owner")
+}
+
 // TestResignBatchAcceptsUniformOwner is the negative control: a batch whose
 // messages all belong to the authorised owner must clear the authorisation stage
 // and fail, if at all, only in ceremony execution.
@@ -282,6 +418,138 @@ func TestReshareBatchRejectsMessageWithDifferentOwner(t *testing.T) {
 
 	require.Contains(t, *env.queried, contractOwner)
 	require.NotContains(t, *env.queried, otherOwner)
+}
+
+// TestReshareBatchRejectsMessageOwnerWhenProofsLookAuthorised is the reshare twin of the
+// resign case: message 0 would run to completion, so an instance exists if and only if
+// the batch was allowed to execute.
+func TestReshareBatchRejectsMessageOwnerWhenProofsLookAuthorised(t *testing.T) {
+	env := newBatchTestEnv(t)
+
+	signedReshare := &wire.SignedReshare{
+		Messages: []*wire.ReshareMessage{
+			env.validReshareMessage(t, contractOwner, bytesRepeat(0xAA, 48)), // would complete
+			env.reshareMessage(otherOwner, bytesRepeat(0xBB, 48), contractOwner),
+		},
+		Signature: bytesRepeat(0x00, 65),
+	}
+
+	_, err := env.handle(t, signedReshare, wire.SignedReshareMessageType, "reshare")
+
+	require.Error(t, err)
+	require.Empty(t, env.swtch.Instances,
+		"the batch must be rejected before any ceremony runs, including the one that would succeed")
+	require.ErrorContains(t, err, "message 1 owner")
+	require.ErrorContains(t, err, "is not the authorised owner")
+}
+
+// TestReshareBatchRejectsProofOwnerMismatch asserts that a reshare message whose own owner
+// is authorised but whose proof names a different owner is rejected.
+//
+// The message is otherwise a ceremony that completes, and this node appears only among the
+// NEW operators — the path on which no proof of ours is ever validated. So if the batch
+// proof-owner loop were removed, nothing downstream would object: the ceremony would run
+// and return no error at all. Both the error and the empty instance map are therefore
+// evidence that the loop ran.
+func TestReshareBatchRejectsProofOwnerMismatch(t *testing.T) {
+	env := newBatchTestEnv(t)
+
+	msg := env.validReshareMessage(t, contractOwner, bytesRepeat(0xAA, 48))
+	msg.Proofs[0].Proof.Owner = otherOwner
+
+	signedReshare := &wire.SignedReshare{
+		Messages:  []*wire.ReshareMessage{msg},
+		Signature: bytesRepeat(0x00, 65),
+	}
+
+	_, err := env.handle(t, signedReshare, wire.SignedReshareMessageType, "reshare")
+
+	require.Error(t, err, "a proof naming another owner must stop the ceremony")
+	require.Empty(t, env.swtch.Instances, "no instance may be created for a rejected message")
+	require.ErrorContains(t, err, "proof 0 owner")
+	require.ErrorContains(t, err, "is not the authorised owner")
+}
+
+// TestReshareOwnerAnchoredToReshareMessage asserts the owner a reshare batch is authorised
+// against comes from the reshare message itself, never from a proof the message carries.
+//
+// The fixture separates the two: the message names an EOA that authorises nothing, while
+// its proof names the contract owner that rubber-stamps any signature. The pin is the
+// record of which address the EIP-1271 check actually queried — an attacker who could move
+// the anchor into the proofs could authorise a batch with an owner of their choosing.
+func TestReshareOwnerAnchoredToReshareMessage(t *testing.T) {
+	env := newBatchTestEnv(t)
+
+	signedReshare := &wire.SignedReshare{
+		Messages: []*wire.ReshareMessage{
+			env.reshareMessage(otherOwner, bytesRepeat(0xAA, 48), contractOwner),
+		},
+		Signature: bytesRepeat(0x00, 65),
+	}
+
+	_, err := env.handle(t, signedReshare, wire.SignedReshareMessageType, "reshare")
+
+	require.Error(t, err)
+	require.Contains(t, *env.queried, otherOwner,
+		"the signature must be verified against the owner named by the reshare message")
+	require.NotContains(t, *env.queried, contractOwner,
+		"an owner named only by a proof must never be asked to authorise the batch")
+	require.ErrorContains(t, err, "failed to verify signed message by owner")
+	require.Empty(t, env.swtch.Instances)
+}
+
+// TestResignBatchUsesEachMessageOperatorSet asserts every message in a batch is run
+// against its OWN operator set, so one message cannot borrow another's membership.
+//
+// Message 1 keeps this node's operator ID but carries a foreign public key for it, and is
+// otherwise a valid ceremony signed by this node's real key. Sourcing the operator set
+// from message 0 would resolve membership from the wrong message and let message 1 run to
+// completion on its own proof, so the pin is the instance count, not the error text.
+func TestResignBatchUsesEachMessageOperatorSet(t *testing.T) {
+	env := newBatchTestEnv(t)
+
+	foreign := env.validResignMessage(t, contractOwner, bytesRepeat(0xBB, 48))
+	foreign.Operators = []*spec.Operator{{ID: env.opID, PubKey: foreignOperatorKey(t)}}
+
+	signedResign := &wire.SignedResign{
+		Messages: []*wire.ResignMessage{
+			env.validResignMessage(t, contractOwner, bytesRepeat(0xAA, 48)),
+			foreign,
+		},
+		Signature: bytesRepeat(0x00, 65),
+	}
+
+	_, err := env.handle(t, signedResign, wire.SignedResignMessageType, "resign")
+
+	require.Error(t, err, "a message listing an operator set this node is not in must be rejected")
+	require.Len(t, env.swtch.Instances, 1,
+		"only the first message may create an instance; the second is not addressed to this node")
+	require.ErrorContains(t, err, "wrong operator")
+}
+
+// TestReshareBatchUsesEachMessageOperatorSet is the reshare twin: message 1's old and new
+// operator sets both exclude this node, so it must be rejected on membership even though
+// message 0 named a set this node belongs to.
+func TestReshareBatchUsesEachMessageOperatorSet(t *testing.T) {
+	env := newBatchTestEnv(t)
+
+	foreign := env.validReshareMessage(t, contractOwner, bytesRepeat(0xBB, 48))
+	foreign.Reshare.NewOperators = foreignOperators(t, 5, 6, 7, 8)
+
+	signedReshare := &wire.SignedReshare{
+		Messages: []*wire.ReshareMessage{
+			env.validReshareMessage(t, contractOwner, bytesRepeat(0xAA, 48)),
+			foreign,
+		},
+		Signature: bytesRepeat(0x00, 65),
+	}
+
+	_, err := env.handle(t, signedReshare, wire.SignedReshareMessageType, "reshare")
+
+	require.Error(t, err, "a message whose operator sets exclude this node must be rejected")
+	require.Len(t, env.swtch.Instances, 1,
+		"only the first message may create an instance; the second is not addressed to this node")
+	require.ErrorContains(t, err, "wrong operator")
 }
 
 // TestInstanceOperationRejectsEmptyBatchAndProofs asserts empty message and proof
@@ -356,49 +624,177 @@ func TestInstanceOperationRejectsEmptyBatchAndProofs(t *testing.T) {
 	}
 }
 
-// TestReshareRejectsStructurallyInvalidMessage asserts a reshare message is checked
-// for structural validity even when this operator appears only among the new
-// operators, so no instance is created for a fabricated message.
+// TestReshareRejectsStructurallyInvalidMessage asserts every structural check on a reshare
+// message runs even when this operator appears only among the NEW operators — the path on
+// which none of the old-operator validation covers the message.
+//
+// One row per predicate, each breaking exactly one field and leaving every other field
+// valid. That matters: a fixture that breaks two fields at once only ever proves the first
+// check reached, and silently leaves the rest unguarded. Each row's base message would run
+// to completion, so an absent error is itself a failure signal.
 func TestReshareRejectsStructurallyInvalidMessage(t *testing.T) {
-	env := newBatchTestEnv(t)
 	validatorPK := bytesRepeat(0xAA, 48)
 
-	// This operator is only among the new operators, so the old-operator validation
-	// path never covers this message.
-	oldOperators := []*spec.Operator{
-		{ID: 30, PubKey: foreignOperatorKey(t)},
-		{ID: 20, PubKey: foreignOperatorKey(t)}, // out of order
-	}
-
-	msg := &wire.ReshareMessage{
-		Reshare: &spec.Reshare{
-			ValidatorPubKey:       validatorPK,
-			OldOperators:          oldOperators,
-			NewOperators:          env.operators(),
-			OldT:                  3,
-			NewT:                  99, // not a valid threshold for the new set
-			WithdrawalCredentials: eth1Creds(),
-			Owner:                 contractOwner,
-			Amount:                uint64(spec_crypto.MIN_ACTIVATION_BALANCE),
+	tests := []struct {
+		name        string
+		breakField  func(r *spec.Reshare)
+		expectedErr string
+	}{
+		{
+			name: "old operators out of order",
+			breakField: func(r *spec.Reshare) {
+				r.OldOperators[0], r.OldOperators[1] = r.OldOperators[1], r.OldOperators[0]
+			},
+			expectedErr: "old operators are not unique and ordered",
 		},
-		Proofs: []*spec.SignedProof{{Proof: &spec.Proof{
-			ValidatorPubKey: validatorPK,
-			EncryptedShare:  bytesRepeat(0x01, 128),
-			SharePubKey:     bytesRepeat(0x00, 48),
-			Owner:           contractOwner,
-		}, Signature: bytesRepeat(0x00, 256)}},
+		{
+			name: "new operators out of order",
+			breakField: func(r *spec.Reshare) {
+				r.NewOperators[0], r.NewOperators[1] = r.NewOperators[1], r.NewOperators[0]
+			},
+			expectedErr: "new operators are not unique and ordered",
+		},
+		{
+			name:        "old threshold not valid for the old set",
+			breakField:  func(r *spec.Reshare) { r.OldT = 99 },
+			expectedErr: "old threshold set is invalid",
+		},
+		{
+			name:        "new threshold not valid for the new set",
+			breakField:  func(r *spec.Reshare) { r.NewT = 99 },
+			expectedErr: "new threshold set is invalid",
+		},
+		{
+			name:        "amount below the activation balance",
+			breakField:  func(r *spec.Reshare) { r.Amount = 1 },
+			expectedErr: "amount should be in range between 32 ETH and 2048 ETH",
+		},
+		{
+			name:        "withdrawal credentials with an unknown prefix",
+			breakField:  func(r *spec.Reshare) { r.WithdrawalCredentials[0] = 0xFF },
+			expectedErr: "invalid withdrawal credentials",
+		},
 	}
 
-	signedReshare := &wire.SignedReshare{
-		Messages:  []*wire.ReshareMessage{msg},
-		Signature: bytesRepeat(0x00, 65),
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			env := newBatchTestEnv(t)
+			msg := env.validReshareMessage(t, contractOwner, validatorPK)
+			tc.breakField(msg.Reshare)
+
+			signedReshare := &wire.SignedReshare{
+				Messages:  []*wire.ReshareMessage{msg},
+				Signature: bytesRepeat(0x00, 65),
+			}
+
+			_, err := env.handle(t, signedReshare, wire.SignedReshareMessageType, "reshare")
+
+			require.Error(t, err, "a message failing this check must not run")
+			require.Empty(t, env.swtch.Instances, "no instance may be created for a malformed message")
+			require.ErrorContains(t, err, tc.expectedErr)
+		})
+	}
+}
+
+// TestReshareRejectsProofsLenMismatch asserts a reshare message is rejected when its
+// proofs and old-operator lists disagree, rather than being indexed into. It is the twin
+// of TestResignRejectsProofsLenMismatch, which covers the resign side of the same guard.
+//
+// The surplus case is the sharp one: recovering the public commitments walks the proofs
+// and indexes the old-operator list in step, so an extra proof reads past the end of it.
+func TestReshareRejectsProofsLenMismatch(t *testing.T) {
+	validatorPK := bytesRepeat(0xAA, 48)
+
+	tests := []struct {
+		name       string
+		fixProofs  func(msg *wire.ReshareMessage)
+		expectedIn string
+	}{
+		{
+			name:       "fewer proofs than old operators",
+			fixProofs:  func(msg *wire.ReshareMessage) { msg.Proofs = msg.Proofs[:len(msg.Proofs)-1] },
+			expectedIn: "expected 4, got 3",
+		},
+		{
+			name:       "more proofs than old operators",
+			fixProofs:  func(msg *wire.ReshareMessage) { msg.Proofs = append(msg.Proofs, msg.Proofs[0]) },
+			expectedIn: "expected 4, got 5",
+		},
 	}
 
-	_, err := env.handle(t, signedReshare, wire.SignedReshareMessageType, "reshare")
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			env := newBatchTestEnv(t)
+			msg := env.validReshareMessage(t, contractOwner, validatorPK)
+			tc.fixProofs(msg)
 
-	require.Error(t, err)
-	require.ErrorContains(t, err, "old operators are not unique and ordered")
-	require.Empty(t, env.swtch.Instances, "no instance may be created for a malformed message")
+			signedReshare := &wire.SignedReshare{
+				Messages:  []*wire.ReshareMessage{msg},
+				Signature: bytesRepeat(0x00, 65),
+			}
+
+			require.NotPanics(t, func() {
+				_, err := env.handle(t, signedReshare, wire.SignedReshareMessageType, "reshare")
+				require.Error(t, err)
+				require.ErrorContains(t, err, "wrong proofs len at reshare message")
+				require.ErrorContains(t, err, tc.expectedIn)
+			}, "a proofs/operators length mismatch must be rejected, not indexed into")
+			require.Empty(t, env.swtch.Instances)
+		})
+	}
+}
+
+// TestCeremonyResponseErrorMasksEverythingExceptVersionMismatch enumerates the error
+// classes a ceremony operation can return and asserts exactly one of them — a version
+// mismatch — reaches the initiator intact.
+//
+// The route-level tests cannot bound this on their own: they exercise three concrete
+// failures, so a carve-out widened to a class none of them produces would ship green. The
+// decryption rows below are the ones that matter most — letting an rsa.ErrDecryption
+// through unmasked is precisely the chosen-ciphertext oracle the masking exists to close.
+func TestCeremonyResponseErrorMasksEverythingExceptVersionMismatch(t *testing.T) {
+	versionMismatch := fmt.Errorf("%w: remote a local b", ErrVersionMismatch)
+
+	tests := []struct {
+		name     string
+		err      error
+		verbatim bool
+	}{
+		{name: "version mismatch", err: versionMismatch, verbatim: true},
+		{name: "version mismatch wrapped by a caller", err: fmt.Errorf("resign: %w", versionMismatch), verbatim: true},
+
+		{name: "share decryption failure", err: rsa.ErrDecryption},
+		{name: "wrapped share decryption failure", err: fmt.Errorf("failed to decrypt encrypted share: %w", rsa.ErrDecryption)},
+		{name: "signature verification failure", err: rsa.ErrVerification},
+		{name: "initiator signature invalid", err: fmt.Errorf("resign: initiator signature isn't valid: %w", rsa.ErrVerification)},
+		{name: "missing instance", err: utils.ErrMissingInstance},
+		{name: "instance already exists", err: utils.ErrAlreadyExists},
+		{name: "max instances reached", err: utils.ErrMaxInstances},
+		{name: "owner signature not verified", err: fmt.Errorf("failed to verify signed message by owner: %w", rsa.ErrVerification)},
+		{name: "unauthorised message owner", err: fmt.Errorf("resign: message 0 owner aa is not the authorised owner bb")},
+		{name: "ceremony execution failure", err: fmt.Errorf("resign: failed to run instance: %w", errors.New("inner detail"))},
+		{name: "empty batch", err: fmt.Errorf("resign: no resign messages")},
+		{name: "unknown operation type", err: fmt.Errorf("unknown operation type: %s", "resign")},
+		{name: "arbitrary ceremony detail", err: errors.New("some arbitrary ceremony detail")},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			respErr := fmt.Errorf("operator 1, failed to resign, err: %w", tc.err)
+
+			got := ceremonyResponseError(tc.err, respErr)
+
+			var sensitive *utils.SensitiveError
+			if tc.verbatim {
+				require.False(t, errors.As(got, &sensitive), "this class must not be masked")
+				require.Equal(t, tc.err, got, "the error must reach the initiator unchanged")
+				return
+			}
+			require.ErrorAs(t, got, &sensitive, "this class must be masked")
+			require.Equal(t, string(wire.InitiatorErrorCodeCeremonyFailed), sensitive.PresentedErr)
+			require.ErrorIs(t, got, tc.err, "the original error must remain available for logs")
+		})
+	}
 }
 
 // TestMaskCeremonyErrorMasksAllErrors asserts the presented error is always the

--- a/pkgs/operator/instances_manager_regression_test.go
+++ b/pkgs/operator/instances_manager_regression_test.go
@@ -1,0 +1,416 @@
+package operator
+
+// Regression tests for resign/reshare batch handling.
+//
+// The invariants under test: one owner signature authorises exactly the messages
+// that belong to that owner, the whole batch is rejected if any message does not,
+// and malformed batches are rejected rather than indexed into.
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"errors"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	spec "github.com/ssvlabs/dkg-spec"
+	spec_crypto "github.com/ssvlabs/dkg-spec/crypto"
+	"github.com/ssvlabs/dkg-spec/eip1271"
+	"github.com/ssvlabs/dkg-spec/testing/stubs"
+	"github.com/ssvlabs/ssv-dkg/pkgs/utils"
+	"github.com/ssvlabs/ssv-dkg/pkgs/wire"
+)
+
+// recordingClient wraps the eth stub and records every address whose account
+// code is queried — i.e. every owner the operator actually checks a signature
+// against.
+type recordingClient struct {
+	*stubs.Client
+	queried *[]common.Address
+}
+
+func (c *recordingClient) CodeAt(ctx context.Context, addr common.Address, block *big.Int) ([]byte, error) {
+	*c.queried = append(*c.queried, addr)
+	return c.Client.CodeAt(ctx, addr, block)
+}
+
+func bytesRepeat(b byte, n int) []byte {
+	out := make([]byte, n)
+	for i := range out {
+		out[i] = b
+	}
+	return out
+}
+
+func eth1Creds() []byte {
+	c := make([]byte, 32)
+	c[0] = 1 // ETH1WithdrawalPrefix
+	return c
+}
+
+// contractOwner is an EIP-1271 owner whose contract approves any signature.
+var contractOwner = common.HexToAddress("0x00000000000000000000000000000000A77ac4e5")
+
+// otherOwner never authorises anything and stays an EOA.
+var otherOwner = common.HexToAddress("0x000000000000000000000000000000000C71c71c")
+
+// batchTestEnv is a Switch wired to an eth stub that rubber-stamps signatures for
+// contractOwner, plus a record of every owner whose authorisation was checked.
+type batchTestEnv struct {
+	swtch   *Switch
+	opID    uint64
+	opPub   []byte
+	version []byte
+	queried *[]common.Address
+}
+
+func newBatchTestEnv(t *testing.T) *batchTestEnv {
+	t.Helper()
+	logger := zap.NewNop()
+	version := []byte("test.version")
+
+	opPriv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	opPub, err := spec_crypto.EncodeRSAPublicKey(&opPriv.PublicKey)
+	require.NoError(t, err)
+	const opID = uint64(1)
+
+	queried := &[]common.Address{}
+	eth := &recordingClient{
+		Client: &stubs.Client{
+			CallContractF: func(call ethereum.CallMsg) ([]byte, error) {
+				ret := make([]byte, 32)
+				copy(ret[:4], eip1271.MAGIC_VALUE[:]) // valid EIP-1271 signature
+				return ret, nil
+			},
+			CodeAtMap: map[common.Address]bool{contractOwner: true}, // contract; other owners stay EOA
+		},
+		queried: queried,
+	}
+
+	return &batchTestEnv{
+		swtch:   NewSwitch(opPriv, logger, version, opPub, opID, eth),
+		opID:    opID,
+		opPub:   opPub,
+		version: version,
+		queried: queried,
+	}
+}
+
+// operators returns an operator list containing this node, so CreateInstance can
+// resolve our own ID once a message gets that far.
+func (e *batchTestEnv) operators() []*spec.Operator {
+	return []*spec.Operator{{ID: e.opID, PubKey: e.opPub}}
+}
+
+// foreignOperatorKey returns an encoded RSA public key belonging to no test node,
+// so operator lookups by public key never resolve to it.
+func foreignOperatorKey(t *testing.T) []byte {
+	t.Helper()
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	pub, err := spec_crypto.EncodeRSAPublicKey(&priv.PublicKey)
+	require.NoError(t, err)
+	return pub
+}
+
+func (e *batchTestEnv) resignMessage(owner common.Address, validatorPK []byte, proofOwners ...common.Address) *wire.ResignMessage {
+	if len(proofOwners) == 0 {
+		proofOwners = []common.Address{owner}
+	}
+	proofs := make([]*spec.SignedProof, 0, len(proofOwners))
+	for _, proofOwner := range proofOwners {
+		proofs = append(proofs, &spec.SignedProof{Proof: &spec.Proof{
+			ValidatorPubKey: validatorPK,
+			EncryptedShare:  bytesRepeat(0x01, 128),
+			SharePubKey:     bytesRepeat(0x00, 48),
+			Owner:           proofOwner,
+		}, Signature: bytesRepeat(0x00, 256)})
+	}
+	return &wire.ResignMessage{
+		Operators: e.operators(),
+		Resign: &spec.Resign{
+			ValidatorPubKey:       validatorPK,
+			WithdrawalCredentials: eth1Creds(),
+			Owner:                 owner,
+			Amount:                uint64(spec_crypto.MIN_ACTIVATION_BALANCE),
+		},
+		Proofs: proofs,
+	}
+}
+
+func (e *batchTestEnv) reshareMessage(owner common.Address, validatorPK []byte) *wire.ReshareMessage {
+	return &wire.ReshareMessage{
+		Reshare: &spec.Reshare{
+			ValidatorPubKey:       validatorPK,
+			OldOperators:          e.operators(),
+			NewOperators:          e.operators(),
+			OldT:                  3,
+			NewT:                  3,
+			WithdrawalCredentials: eth1Creds(),
+			Owner:                 owner,
+			Amount:                uint64(spec_crypto.MIN_ACTIVATION_BALANCE),
+		},
+		Proofs: []*spec.SignedProof{{Proof: &spec.Proof{
+			ValidatorPubKey: validatorPK,
+			EncryptedShare:  bytesRepeat(0x01, 128),
+			SharePubKey:     bytesRepeat(0x00, 48),
+			Owner:           owner,
+		}, Signature: bytesRepeat(0x00, 256)}},
+	}
+}
+
+// handle marshals data as the given transport type, signs it with a throwaway
+// initiator key and drives HandleInstanceOperation.
+func (e *batchTestEnv) handle(t *testing.T, msg wire.SSZMarshaller, msgType wire.TransportType, operationType string) ([][]byte, error) {
+	t.Helper()
+	data, err := msg.MarshalSSZ()
+	require.NoError(t, err)
+
+	var reqID [24]byte
+	transport := &wire.Transport{Type: msgType, Identifier: reqID, Data: data, Version: e.version}
+	tBytes, err := transport.MarshalSSZ()
+	require.NoError(t, err)
+
+	// Any initiator may send this — the operator authenticates the initiator's own
+	// key, not an allow-list.
+	initPriv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	initPub, err := spec_crypto.EncodeRSAPublicKey(&initPriv.PublicKey)
+	require.NoError(t, err)
+	initSig, err := spec_crypto.SignRSA(initPriv, tBytes)
+	require.NoError(t, err)
+
+	return e.swtch.HandleInstanceOperation(reqID, transport, initPub, initSig, operationType)
+}
+
+// TestResignBatchRejectsMessageWithDifferentOwner asserts a batch carrying two
+// different owners is rejected outright, and that no ceremony runs for either
+// message. Only the first message's owner authorised anything.
+func TestResignBatchRejectsMessageWithDifferentOwner(t *testing.T) {
+	env := newBatchTestEnv(t)
+
+	signedResign := &wire.SignedResign{
+		Messages: []*wire.ResignMessage{
+			env.resignMessage(contractOwner, bytesRepeat(0xAA, 48)), // authorises the batch
+			env.resignMessage(otherOwner, bytesRepeat(0xBB, 48)),    // never authorised
+		},
+		Signature: bytesRepeat(0x00, 65),
+	}
+
+	_, err := env.handle(t, signedResign, wire.SignedResignMessageType, "resign")
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "is not the authorised owner")
+	require.NotContains(t, err.Error(), "failed to run instance",
+		"the batch must be rejected before any ceremony runs")
+	require.Empty(t, env.swtch.Instances, "no instance may be created for either message")
+
+	require.Contains(t, *env.queried, contractOwner, "message 0 owner authorised the batch")
+	require.NotContains(t, *env.queried, otherOwner,
+		"message 1's owner never authorised anything, so its message must not execute")
+}
+
+// TestResignBatchRejectsProofOwnerMismatch asserts that a message whose own owner
+// is authorised but whose proofs name a different owner is still rejected.
+func TestResignBatchRejectsProofOwnerMismatch(t *testing.T) {
+	env := newBatchTestEnv(t)
+
+	signedResign := &wire.SignedResign{
+		Messages: []*wire.ResignMessage{
+			env.resignMessage(contractOwner, bytesRepeat(0xAA, 48), otherOwner),
+		},
+		Signature: bytesRepeat(0x00, 65),
+	}
+
+	_, err := env.handle(t, signedResign, wire.SignedResignMessageType, "resign")
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "proof 0 owner")
+	require.ErrorContains(t, err, "is not the authorised owner")
+	require.Empty(t, env.swtch.Instances)
+}
+
+// TestResignBatchAcceptsUniformOwner is the negative control: a batch whose
+// messages all belong to the authorised owner must clear the authorisation stage
+// and fail, if at all, only in ceremony execution.
+func TestResignBatchAcceptsUniformOwner(t *testing.T) {
+	env := newBatchTestEnv(t)
+
+	signedResign := &wire.SignedResign{
+		Messages: []*wire.ResignMessage{
+			env.resignMessage(contractOwner, bytesRepeat(0xAA, 48)),
+			env.resignMessage(contractOwner, bytesRepeat(0xBB, 48)),
+		},
+		Signature: bytesRepeat(0x00, 65),
+	}
+
+	_, err := env.handle(t, signedResign, wire.SignedResignMessageType, "resign")
+
+	require.Error(t, err, "the placeholder proofs still fail ceremony validation")
+	require.NotContains(t, err.Error(), "is not the authorised owner",
+		"a uniformly owned batch must not be rejected by the authorisation stage")
+	require.ErrorContains(t, err, "failed to run instance")
+}
+
+// TestReshareBatchRejectsMessageWithDifferentOwner mirrors the resign case on the
+// reshare branch.
+func TestReshareBatchRejectsMessageWithDifferentOwner(t *testing.T) {
+	env := newBatchTestEnv(t)
+
+	signedReshare := &wire.SignedReshare{
+		Messages: []*wire.ReshareMessage{
+			env.reshareMessage(contractOwner, bytesRepeat(0xAA, 48)),
+			env.reshareMessage(otherOwner, bytesRepeat(0xBB, 48)),
+		},
+		Signature: bytesRepeat(0x00, 65),
+	}
+
+	_, err := env.handle(t, signedReshare, wire.SignedReshareMessageType, "reshare")
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "is not the authorised owner")
+	require.NotContains(t, err.Error(), "failed to run instance",
+		"the batch must be rejected before any ceremony runs")
+	require.Empty(t, env.swtch.Instances)
+
+	require.Contains(t, *env.queried, contractOwner)
+	require.NotContains(t, *env.queried, otherOwner)
+}
+
+// TestInstanceOperationRejectsEmptyBatchAndProofs asserts empty message and proof
+// lists — both valid SSZ — are rejected rather than indexed into.
+func TestInstanceOperationRejectsEmptyBatchAndProofs(t *testing.T) {
+	validatorPK := bytesRepeat(0xAA, 48)
+
+	tests := []struct {
+		name          string
+		operationType string
+		msgType       wire.TransportType
+		message       func(e *batchTestEnv) wire.SSZMarshaller
+		expectedErr   string
+	}{
+		{
+			name:          "resign without messages",
+			operationType: "resign",
+			msgType:       wire.SignedResignMessageType,
+			message: func(e *batchTestEnv) wire.SSZMarshaller {
+				return &wire.SignedResign{Signature: bytesRepeat(0x00, 65)}
+			},
+			expectedErr: "no resign messages",
+		},
+		{
+			name:          "reshare without messages",
+			operationType: "reshare",
+			msgType:       wire.SignedReshareMessageType,
+			message: func(e *batchTestEnv) wire.SSZMarshaller {
+				return &wire.SignedReshare{Signature: bytesRepeat(0x00, 65)}
+			},
+			expectedErr: "no reshare messages",
+		},
+		{
+			name:          "resign message without proofs",
+			operationType: "resign",
+			msgType:       wire.SignedResignMessageType,
+			message: func(e *batchTestEnv) wire.SSZMarshaller {
+				msg := e.resignMessage(contractOwner, validatorPK)
+				msg.Proofs = nil
+				return &wire.SignedResign{
+					Messages:  []*wire.ResignMessage{msg},
+					Signature: bytesRepeat(0x00, 65),
+				}
+			},
+			expectedErr: "message 0 has no proofs",
+		},
+		{
+			name:          "reshare message without proofs",
+			operationType: "reshare",
+			msgType:       wire.SignedReshareMessageType,
+			message: func(e *batchTestEnv) wire.SSZMarshaller {
+				msg := e.reshareMessage(contractOwner, validatorPK)
+				msg.Proofs = nil
+				return &wire.SignedReshare{
+					Messages:  []*wire.ReshareMessage{msg},
+					Signature: bytesRepeat(0x00, 65),
+				}
+			},
+			expectedErr: "message 0 has no proofs",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			env := newBatchTestEnv(t)
+			require.NotPanics(t, func() {
+				_, err := env.handle(t, tc.message(env), tc.msgType, tc.operationType)
+				require.ErrorContains(t, err, tc.expectedErr)
+			})
+			require.Empty(t, env.swtch.Instances)
+		})
+	}
+}
+
+// TestReshareRejectsStructurallyInvalidMessage asserts a reshare message is checked
+// for structural validity even when this operator appears only among the new
+// operators, so no instance is created for a fabricated message.
+func TestReshareRejectsStructurallyInvalidMessage(t *testing.T) {
+	env := newBatchTestEnv(t)
+	validatorPK := bytesRepeat(0xAA, 48)
+
+	// This operator is only among the new operators, so the old-operator validation
+	// path never covers this message.
+	oldOperators := []*spec.Operator{
+		{ID: 30, PubKey: foreignOperatorKey(t)},
+		{ID: 20, PubKey: foreignOperatorKey(t)}, // out of order
+	}
+
+	msg := &wire.ReshareMessage{
+		Reshare: &spec.Reshare{
+			ValidatorPubKey:       validatorPK,
+			OldOperators:          oldOperators,
+			NewOperators:          env.operators(),
+			OldT:                  3,
+			NewT:                  99, // not a valid threshold for the new set
+			WithdrawalCredentials: eth1Creds(),
+			Owner:                 contractOwner,
+			Amount:                uint64(spec_crypto.MIN_ACTIVATION_BALANCE),
+		},
+		Proofs: []*spec.SignedProof{{Proof: &spec.Proof{
+			ValidatorPubKey: validatorPK,
+			EncryptedShare:  bytesRepeat(0x01, 128),
+			SharePubKey:     bytesRepeat(0x00, 48),
+			Owner:           contractOwner,
+		}, Signature: bytesRepeat(0x00, 256)}},
+	}
+
+	signedReshare := &wire.SignedReshare{
+		Messages:  []*wire.ReshareMessage{msg},
+		Signature: bytesRepeat(0x00, 65),
+	}
+
+	_, err := env.handle(t, signedReshare, wire.SignedReshareMessageType, "reshare")
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "old operators are not unique and ordered")
+	require.Empty(t, env.swtch.Instances, "no instance may be created for a malformed message")
+}
+
+// TestMaskCeremonyErrorMasksAllErrors asserts the presented error is always the
+// generic ceremony code while the original error stays available for logging.
+func TestMaskCeremonyErrorMasksAllErrors(t *testing.T) {
+	original := errors.New("internal ceremony detail")
+
+	masked := maskCeremonyError(original)
+
+	var sensitive *utils.SensitiveError
+	require.ErrorAs(t, masked, &sensitive)
+	require.Equal(t, string(wire.InitiatorErrorCodeCeremonyFailed), sensitive.PresentedErr)
+	require.ErrorIs(t, masked, original, "the original error must remain available for logs")
+	require.Equal(t, original.Error(), masked.Error())
+}

--- a/pkgs/operator/reshare_share_regression_test.go
+++ b/pkgs/operator/reshare_share_regression_test.go
@@ -1,0 +1,91 @@
+package operator
+
+// Regression test for the reshare share-recovery ordering.
+//
+// The invariant under test is the reshare twin of the one pinned on the resign path: a
+// ceremony proof is validated against this operator's OWN key, and only then is the
+// encrypted share it carries decrypted. Decrypting first — even discarding the result
+// when validation later fails — turns the route into a chosen-ciphertext oracle.
+
+import (
+	"crypto/rsa"
+	"testing"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	spec "github.com/ssvlabs/dkg-spec"
+	spec_crypto "github.com/ssvlabs/dkg-spec/crypto"
+	"github.com/ssvlabs/dkg-spec/testing/stubs"
+	"github.com/ssvlabs/ssv-dkg/pkgs/crypto"
+	"github.com/ssvlabs/ssv-dkg/pkgs/wire"
+)
+
+// TestReshareValidatesProofBeforeDecryptingShare asserts the reshare path never decrypts a
+// share whose proof does not validate against this operator's own key.
+//
+// There is no injectable decryption seam here — GetSecretShareFromProofs takes the
+// operator's *rsa.PrivateKey directly — so the observation is made the other way round:
+// the switch is built with NO private key at all. A decryption attempted before validation
+// therefore dereferences a nil key and panics, which makes "did not panic" a statement
+// about execution order rather than about the wording of an error. The switch's public key
+// is set independently, so validation still has everything it needs to reject the proof.
+func TestReshareValidatesProofBeforeDecryptingShare(t *testing.T) {
+	const opID = uint64(1)
+	validatorPK := bytesRepeat(0xAA, 48)
+
+	opPub, err := spec_crypto.EncodeRSAPublicKey(&mustRSAKey(t).PublicKey)
+	require.NoError(t, err)
+
+	eth := &stubs.Client{
+		CallContractF: func(call ethereum.CallMsg) ([]byte, error) { return nil, nil },
+	}
+	// No private key: any decryption on this switch is a hard, visible failure.
+	s := NewSwitch(nil, zap.NewNop(), []byte("test.version"), opPub, opID, eth)
+
+	// This operator IS among the old operators, so the branch that validates our proof
+	// and decrypts our share is live. Old and new sets differ, as the spec requires.
+	oldOperators := append([]*spec.Operator{{ID: opID, PubKey: opPub}}, foreignOperators(t, 2, 3, 4)...)
+	proofs := make([]*spec.SignedProof, 0, len(oldOperators))
+	for range oldOperators {
+		proofs = append(proofs, &spec.SignedProof{Proof: &spec.Proof{
+			ValidatorPubKey: validatorPK,
+			EncryptedShare:  bytesRepeat(0x01, 128),
+			SharePubKey:     blsSharePubKey(t),
+			Owner:           contractOwner,
+			// signed by nobody: verification against our own public key must reject it
+		}, Signature: bytesRepeat(0x00, 256)})
+	}
+
+	msg := &wire.ReshareMessage{
+		Reshare: &spec.Reshare{
+			ValidatorPubKey:       validatorPK,
+			OldOperators:          oldOperators,
+			NewOperators:          foreignOperators(t, 5, 6, 7, 8),
+			OldT:                  3,
+			NewT:                  3,
+			WithdrawalCredentials: eth1Creds(),
+			Owner:                 contractOwner,
+			Amount:                uint64(spec_crypto.MIN_ACTIVATION_BALANCE),
+		},
+		Proofs: proofs,
+	}
+
+	// Precondition: the seam is live. Asserted on the exact call the ordering protects, so
+	// this fails loudly if that call ever stops being nil-hostile, rather than letting the
+	// test below silently stop proving anything.
+	require.Panics(t, func() {
+		_, _ = crypto.GetSecretShareFromProofs(msg.Proofs[0], nil, opID)
+	}, "share decryption must be nil-hostile for this test to observe anything")
+
+	var recoverErr error
+	require.NotPanics(t, func() {
+		_, _, recoverErr = s.getPublicCommitsAndSecretShare(msg)
+	}, "the share must not be decrypted before its proof is validated")
+
+	require.Error(t, recoverErr)
+	require.ErrorIs(t, recoverErr, rsa.ErrVerification,
+		"the request must stop at proof verification")
+	require.NotContains(t, recoverErr.Error(), "decrypt")
+}

--- a/pkgs/operator/router.go
+++ b/pkgs/operator/router.go
@@ -4,12 +4,15 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
 	"github.com/go-chi/httprate"
 	"go.uber.org/zap"
 )
 
 // RegisterRoutes creates routes at operator to process messages incoming from initiator
 func RegisterRoutes(s *Server) {
+	// installed first so it also contains panics raised inside other middleware
+	s.Router.Use(middleware.Recoverer)
 	s.Router.Use(rateLimit(s.Logger, generalLimit))
 
 	addRoute(s.Router, "POST", "/init", s.initHandler, rateLimit(s.Logger, initRouteLimit))

--- a/pkgs/operator/router_regression_test.go
+++ b/pkgs/operator/router_regression_test.go
@@ -302,8 +302,10 @@ func TestCeremonyRoutesReportVersionMismatch(t *testing.T) {
 			require.Equal(t, http.StatusBadRequest, recorder.Code)
 			body, err := wire.ParseAsError(recorder.Body.Bytes())
 			require.NoError(t, err)
-			require.Equal(t, "wrong version: remote other.version local test.version", body,
-				"a version mismatch must name both versions so it can be acted on")
+			require.Equal(t, "wrong version: operator runs test.version", body,
+				"a version mismatch must name the operator's version so it can be acted on")
+			require.NotContains(t, body, "other.version",
+				"the caller-supplied version must never be echoed back")
 			require.NotContains(t, body, string(wire.InitiatorErrorCodeCeremonyFailed))
 		})
 	}

--- a/pkgs/operator/router_regression_test.go
+++ b/pkgs/operator/router_regression_test.go
@@ -1,0 +1,297 @@
+package operator
+
+// Regression tests for request-level fault containment.
+//
+// The invariant under test: a malformed request cannot take the server down. These
+// must be driven through the router, because containment is installed as router
+// middleware — calling a handler or the Switch directly bypasses it.
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	spec "github.com/ssvlabs/dkg-spec"
+	spec_crypto "github.com/ssvlabs/dkg-spec/crypto"
+	"github.com/ssvlabs/dkg-spec/testing/stubs"
+	"github.com/ssvlabs/ssv-dkg/pkgs/wire"
+)
+
+// routerTestEnv is a Server with the real routes registered, driven in-process.
+type routerTestEnv struct {
+	server  *Server
+	opPub   []byte
+	opID    uint64
+	version []byte
+}
+
+func newRouterTestEnv(t *testing.T) *routerTestEnv {
+	t.Helper()
+	version := []byte("test.version")
+
+	opPriv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	opPub, err := spec_crypto.EncodeRSAPublicKey(&opPriv.PublicKey)
+	require.NoError(t, err)
+	const opID = uint64(1)
+
+	// Default stub: any owner address is an EOA, so signature recovery is attempted.
+	eth := &stubs.Client{
+		CallContractF: func(call ethereum.CallMsg) ([]byte, error) {
+			return nil, nil
+		},
+	}
+
+	server := &Server{
+		Logger: zap.NewNop(),
+		Router: chi.NewRouter(),
+		State:  NewSwitch(opPriv, zap.NewNop(), version, opPub, opID, eth),
+	}
+	RegisterRoutes(server)
+
+	return &routerTestEnv{server: server, opPub: opPub, opID: opID, version: version}
+}
+
+// post sends a signed transport to the given route through the router and returns
+// the response recorder.
+func (e *routerTestEnv) post(t *testing.T, route string, signed *wire.SignedTransport) *httptest.ResponseRecorder {
+	t.Helper()
+	body, err := signed.MarshalSSZ()
+	require.NoError(t, err)
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, route, bytes.NewReader(body))
+	e.server.Router.ServeHTTP(recorder, request)
+	return recorder
+}
+
+// nonRSAPublicKey returns an encoded public key that parses as valid PEM but is not
+// an RSA key.
+func nonRSAPublicKey(t *testing.T) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	der, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
+	require.NoError(t, err)
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der})
+	return []byte(base64.StdEncoding.EncodeToString(pemBytes))
+}
+
+// TestRouterContainsNonRSAInitiatorKey asserts a request whose initiator key is a
+// well-formed but non-RSA public key is contained instead of taking the server down.
+func TestRouterContainsNonRSAInitiatorKey(t *testing.T) {
+	validatorPK := bytesRepeat(0xAA, 48)
+
+	tests := []struct {
+		name    string
+		route   string
+		msgType wire.TransportType
+		data    func(e *routerTestEnv) wire.SSZMarshaller
+	}{
+		{
+			name:    "init",
+			route:   "/init",
+			msgType: wire.InitMessageType,
+			data: func(e *routerTestEnv) wire.SSZMarshaller {
+				// a structurally valid init message, so the request reaches the point
+				// where the initiator key is parsed
+				return &spec.Init{
+					Operators: []*spec.Operator{
+						{ID: e.opID, PubKey: e.opPub},
+						{ID: e.opID + 1, PubKey: foreignOperatorKey(t)},
+						{ID: e.opID + 2, PubKey: foreignOperatorKey(t)},
+						{ID: e.opID + 3, PubKey: foreignOperatorKey(t)},
+					},
+					T:                     3,
+					WithdrawalCredentials: eth1Creds(),
+					Owner:                 contractOwner,
+					Amount:                uint64(spec_crypto.MIN_ACTIVATION_BALANCE),
+				}
+			},
+		},
+		{
+			name:    "resign",
+			route:   "/resign",
+			msgType: wire.SignedResignMessageType,
+			data: func(e *routerTestEnv) wire.SSZMarshaller {
+				return &wire.SignedResign{
+					Messages: []*wire.ResignMessage{{
+						Operators: []*spec.Operator{{ID: e.opID, PubKey: e.opPub}},
+						Resign: &spec.Resign{
+							ValidatorPubKey:       validatorPK,
+							WithdrawalCredentials: eth1Creds(),
+							Owner:                 contractOwner,
+							Amount:                uint64(spec_crypto.MIN_ACTIVATION_BALANCE),
+						},
+						Proofs: []*spec.SignedProof{{Proof: &spec.Proof{
+							ValidatorPubKey: validatorPK,
+							EncryptedShare:  bytesRepeat(0x01, 128),
+							SharePubKey:     bytesRepeat(0x00, 48),
+							Owner:           contractOwner,
+						}, Signature: bytesRepeat(0x00, 256)}},
+					}},
+					Signature: bytesRepeat(0x00, 65),
+				}
+			},
+		},
+		{
+			name:    "reshare",
+			route:   "/reshare",
+			msgType: wire.SignedReshareMessageType,
+			data: func(e *routerTestEnv) wire.SSZMarshaller {
+				return &wire.SignedReshare{
+					Messages: []*wire.ReshareMessage{{
+						Reshare: &spec.Reshare{
+							ValidatorPubKey:       validatorPK,
+							OldOperators:          []*spec.Operator{{ID: e.opID, PubKey: e.opPub}},
+							NewOperators:          []*spec.Operator{{ID: e.opID, PubKey: e.opPub}},
+							OldT:                  3,
+							NewT:                  3,
+							WithdrawalCredentials: eth1Creds(),
+							Owner:                 contractOwner,
+							Amount:                uint64(spec_crypto.MIN_ACTIVATION_BALANCE),
+						},
+						Proofs: []*spec.SignedProof{{Proof: &spec.Proof{
+							ValidatorPubKey: validatorPK,
+							EncryptedShare:  bytesRepeat(0x01, 128),
+							SharePubKey:     bytesRepeat(0x00, 48),
+							Owner:           contractOwner,
+						}, Signature: bytesRepeat(0x00, 256)}},
+					}},
+					Signature: bytesRepeat(0x00, 65),
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			env := newRouterTestEnv(t)
+			data, err := tc.data(env).MarshalSSZ()
+			require.NoError(t, err)
+
+			var reqID [24]byte
+			signed := &wire.SignedTransport{
+				Message:   &wire.Transport{Type: tc.msgType, Identifier: reqID, Data: data, Version: env.version},
+				Signer:    nonRSAPublicKey(t),
+				Signature: bytesRepeat(0x00, 256),
+			}
+
+			var recorder *httptest.ResponseRecorder
+			require.NotPanics(t, func() {
+				recorder = env.post(t, tc.route, signed)
+			}, "a non-RSA initiator key must not escape as a panic")
+			require.NotEqual(t, http.StatusOK, recorder.Code)
+		})
+	}
+}
+
+// TestRouterContainsShortOwnerSignature asserts a batch carrying an owner signature
+// shorter than an ECDSA signature is contained instead of taking the server down.
+func TestRouterContainsShortOwnerSignature(t *testing.T) {
+	validatorPK := bytesRepeat(0xAA, 48)
+	eoaOwner := common.HexToAddress("0x000000000000000000000000000000000C71c71c")
+
+	tests := []struct {
+		name    string
+		route   string
+		msgType wire.TransportType
+		data    func(e *routerTestEnv) wire.SSZMarshaller
+	}{
+		{
+			name:    "resign",
+			route:   "/resign",
+			msgType: wire.SignedResignMessageType,
+			data: func(e *routerTestEnv) wire.SSZMarshaller {
+				return &wire.SignedResign{
+					Messages: []*wire.ResignMessage{{
+						Operators: []*spec.Operator{{ID: e.opID, PubKey: e.opPub}},
+						Resign: &spec.Resign{
+							ValidatorPubKey:       validatorPK,
+							WithdrawalCredentials: eth1Creds(),
+							Owner:                 eoaOwner,
+							Amount:                uint64(spec_crypto.MIN_ACTIVATION_BALANCE),
+						},
+						Proofs: []*spec.SignedProof{{Proof: &spec.Proof{
+							ValidatorPubKey: validatorPK,
+							EncryptedShare:  bytesRepeat(0x01, 128),
+							SharePubKey:     bytesRepeat(0x00, 48),
+							Owner:           eoaOwner,
+						}, Signature: bytesRepeat(0x00, 256)}},
+					}},
+					Signature: bytesRepeat(0x00, 8), // shorter than an ECDSA signature
+				}
+			},
+		},
+		{
+			name:    "reshare",
+			route:   "/reshare",
+			msgType: wire.SignedReshareMessageType,
+			data: func(e *routerTestEnv) wire.SSZMarshaller {
+				return &wire.SignedReshare{
+					Messages: []*wire.ReshareMessage{{
+						Reshare: &spec.Reshare{
+							ValidatorPubKey:       validatorPK,
+							OldOperators:          []*spec.Operator{{ID: e.opID, PubKey: e.opPub}},
+							NewOperators:          []*spec.Operator{{ID: e.opID, PubKey: e.opPub}},
+							OldT:                  3,
+							NewT:                  3,
+							WithdrawalCredentials: eth1Creds(),
+							Owner:                 eoaOwner,
+							Amount:                uint64(spec_crypto.MIN_ACTIVATION_BALANCE),
+						},
+						Proofs: []*spec.SignedProof{{Proof: &spec.Proof{
+							ValidatorPubKey: validatorPK,
+							EncryptedShare:  bytesRepeat(0x01, 128),
+							SharePubKey:     bytesRepeat(0x00, 48),
+							Owner:           eoaOwner,
+						}, Signature: bytesRepeat(0x00, 256)}},
+					}},
+					Signature: bytesRepeat(0x00, 8),
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			env := newRouterTestEnv(t)
+			data, err := tc.data(env).MarshalSSZ()
+			require.NoError(t, err)
+
+			var reqID [24]byte
+			message := &wire.Transport{Type: tc.msgType, Identifier: reqID, Data: data, Version: env.version}
+			msgBytes, err := message.MarshalSSZ()
+			require.NoError(t, err)
+
+			initPriv, err := rsa.GenerateKey(rand.Reader, 2048)
+			require.NoError(t, err)
+			initPub, err := spec_crypto.EncodeRSAPublicKey(&initPriv.PublicKey)
+			require.NoError(t, err)
+			initSig, err := spec_crypto.SignRSA(initPriv, msgBytes)
+			require.NoError(t, err)
+
+			signed := &wire.SignedTransport{Message: message, Signer: initPub, Signature: initSig}
+
+			var recorder *httptest.ResponseRecorder
+			require.NotPanics(t, func() {
+				recorder = env.post(t, tc.route, signed)
+			}, "a short owner signature must not escape as a panic")
+			require.NotEqual(t, http.StatusOK, recorder.Code)
+		})
+	}
+}

--- a/pkgs/operator/router_regression_test.go
+++ b/pkgs/operator/router_regression_test.go
@@ -27,6 +27,7 @@ import (
 
 	spec "github.com/ssvlabs/dkg-spec"
 	spec_crypto "github.com/ssvlabs/dkg-spec/crypto"
+	"github.com/ssvlabs/dkg-spec/eip1271"
 	"github.com/ssvlabs/dkg-spec/testing/stubs"
 	"github.com/ssvlabs/ssv-dkg/pkgs/wire"
 )
@@ -41,6 +42,18 @@ type routerTestEnv struct {
 
 func newRouterTestEnv(t *testing.T) *routerTestEnv {
 	t.Helper()
+	// Default stub: any owner address is an EOA, so signature recovery is attempted.
+	return newRouterTestEnvWithETH(t, &stubs.Client{
+		CallContractF: func(call ethereum.CallMsg) ([]byte, error) {
+			return nil, nil
+		},
+	})
+}
+
+// newRouterTestEnvWithETH builds the same in-process server against a caller-supplied eth
+// client, so a test can arrange for owner authorisation to succeed and reach the ceremony.
+func newRouterTestEnvWithETH(t *testing.T, eth eip1271.ETHClient) *routerTestEnv {
+	t.Helper()
 	version := []byte("test.version")
 
 	opPriv, err := rsa.GenerateKey(rand.Reader, 2048)
@@ -48,13 +61,6 @@ func newRouterTestEnv(t *testing.T) *routerTestEnv {
 	opPub, err := spec_crypto.EncodeRSAPublicKey(&opPriv.PublicKey)
 	require.NoError(t, err)
 	const opID = uint64(1)
-
-	// Default stub: any owner address is an EOA, so signature recovery is attempted.
-	eth := &stubs.Client{
-		CallContractF: func(call ethereum.CallMsg) ([]byte, error) {
-			return nil, nil
-		},
-	}
 
 	server := &Server{
 		Logger: zap.NewNop(),
@@ -77,6 +83,230 @@ func (e *routerTestEnv) post(t *testing.T, route string, signed *wire.SignedTran
 	request := httptest.NewRequest(http.MethodPost, route, bytes.NewReader(body))
 	e.server.Router.ServeHTTP(recorder, request)
 	return recorder
+}
+
+// newCeremonyRouterEnv returns a router env whose eth stub treats contractOwner as a
+// contract that approves any signature, so a request clears owner authorisation and fails
+// inside the ceremony instead of in front of it.
+func newCeremonyRouterEnv(t *testing.T) *routerTestEnv {
+	t.Helper()
+	return newRouterTestEnvWithETH(t, &stubs.Client{
+		CallContractF: func(call ethereum.CallMsg) ([]byte, error) {
+			ret := make([]byte, 32)
+			copy(ret[:4], eip1271.MAGIC_VALUE[:]) // valid EIP-1271 signature
+			return ret, nil
+		},
+		CodeAtMap: map[common.Address]bool{contractOwner: true},
+	})
+}
+
+// transportFor marshals a ceremony message into a transport at the given version.
+func (e *routerTestEnv) transportFor(t *testing.T, msgType wire.TransportType, msg wire.SSZMarshaller, version []byte) *wire.Transport {
+	t.Helper()
+	data, err := msg.MarshalSSZ()
+	require.NoError(t, err)
+	var reqID [24]byte
+	return &wire.Transport{Type: msgType, Identifier: reqID, Data: data, Version: version}
+}
+
+// signAsInitiator wraps a transport in a signature from a throwaway initiator key. The
+// operator authenticates the initiator's own key rather than an allow-list, so any key works.
+func signAsInitiator(t *testing.T, message *wire.Transport) *wire.SignedTransport {
+	t.Helper()
+	msgBytes, err := message.MarshalSSZ()
+	require.NoError(t, err)
+	initPriv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	initPub, err := spec_crypto.EncodeRSAPublicKey(&initPriv.PublicKey)
+	require.NoError(t, err)
+	initSig, err := spec_crypto.SignRSA(initPriv, msgBytes)
+	require.NoError(t, err)
+	return &wire.SignedTransport{Message: message, Signer: initPub, Signature: initSig}
+}
+
+// resignBatchSignedByForeignKey builds a well-formed resign batch whose proof is signed by
+// a key that is not this operator's, so it is rejected deep inside the ceremony, by
+// LocalOwner.Resign, after owner authorisation has already succeeded.
+func (e *routerTestEnv) resignBatchSignedByForeignKey(t *testing.T) *wire.SignedResign {
+	t.Helper()
+	validatorPK := bytesRepeat(0xAA, 48)
+	proof := &spec.Proof{
+		ValidatorPubKey: validatorPK,
+		EncryptedShare:  bytesRepeat(0x01, 128),
+		SharePubKey:     bytesRepeat(0x00, 48),
+		Owner:           contractOwner,
+	}
+	root, err := proof.HashTreeRoot()
+	require.NoError(t, err)
+	foreignPriv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	signature, err := spec_crypto.SignRSA(foreignPriv, root[:])
+	require.NoError(t, err)
+
+	return &wire.SignedResign{
+		Messages: []*wire.ResignMessage{{
+			Operators: []*spec.Operator{{ID: e.opID, PubKey: e.opPub}},
+			Resign: &spec.Resign{
+				ValidatorPubKey:       validatorPK,
+				WithdrawalCredentials: eth1Creds(),
+				Owner:                 contractOwner,
+				Amount:                uint64(spec_crypto.MIN_ACTIVATION_BALANCE),
+			},
+			Proofs: []*spec.SignedProof{{Proof: proof, Signature: signature}},
+		}},
+		Signature: bytesRepeat(0x00, 65),
+	}
+}
+
+// reshareBatchStructurallyInvalid builds a reshare batch whose operator sets cannot carry
+// the threshold it advertises, so it is rejected by the structural checks.
+func (e *routerTestEnv) reshareBatchStructurallyInvalid(t *testing.T) *wire.SignedReshare {
+	t.Helper()
+	validatorPK := bytesRepeat(0xAA, 48)
+	return &wire.SignedReshare{
+		Messages: []*wire.ReshareMessage{{
+			Reshare: &spec.Reshare{
+				ValidatorPubKey:       validatorPK,
+				OldOperators:          []*spec.Operator{{ID: e.opID, PubKey: e.opPub}},
+				NewOperators:          []*spec.Operator{{ID: e.opID, PubKey: e.opPub}},
+				OldT:                  3,
+				NewT:                  3,
+				WithdrawalCredentials: eth1Creds(),
+				Owner:                 contractOwner,
+				Amount:                uint64(spec_crypto.MIN_ACTIVATION_BALANCE),
+			},
+			Proofs: []*spec.SignedProof{{Proof: &spec.Proof{
+				ValidatorPubKey: validatorPK,
+				EncryptedShare:  bytesRepeat(0x01, 128),
+				SharePubKey:     bytesRepeat(0x00, 48),
+				Owner:           contractOwner,
+			}, Signature: bytesRepeat(0x00, 256)}},
+		}},
+		Signature: bytesRepeat(0x00, 65),
+	}
+}
+
+// TestCeremonyRoutesMaskFailureDetail asserts /resign and /reshare tell the initiator
+// nothing about WHY a ceremony failed beyond a fixed code. The response to a failed
+// ceremony is an oracle if it varies with the request, so the body must be the same code
+// whatever went wrong and wherever it went wrong.
+//
+// The third row is a preflight failure rather than a ceremony one. It is here to bound the
+// one carve-out these routes make — a version mismatch is reported verbatim — by pinning a
+// neighbouring error raised a few lines away in the same function, which must stay masked.
+func TestCeremonyRoutesMaskFailureDetail(t *testing.T) {
+	tests := []struct {
+		name          string
+		route         string
+		msgType       wire.TransportType
+		message       func(e *routerTestEnv) wire.SSZMarshaller
+		validInitSig  bool
+		mustNotAppear []string
+	}{
+		{
+			name:    "resign proof signed by a foreign key",
+			route:   "/resign",
+			msgType: wire.SignedResignMessageType,
+			message: func(e *routerTestEnv) wire.SSZMarshaller {
+				return e.resignBatchSignedByForeignKey(t)
+			},
+			validInitSig:  true,
+			mustNotAppear: []string{"crypto/rsa", "verification", "validate resign message"},
+		},
+		{
+			name:    "reshare structurally invalid",
+			route:   "/reshare",
+			msgType: wire.SignedReshareMessageType,
+			message: func(e *routerTestEnv) wire.SSZMarshaller {
+				return e.reshareBatchStructurallyInvalid(t)
+			},
+			validInitSig:  true,
+			mustNotAppear: []string{"threshold", "operators"},
+		},
+		{
+			name:    "resign with an invalid initiator signature",
+			route:   "/resign",
+			msgType: wire.SignedResignMessageType,
+			message: func(e *routerTestEnv) wire.SSZMarshaller {
+				return e.resignBatchSignedByForeignKey(t)
+			},
+			validInitSig:  false,
+			mustNotAppear: []string{"crypto/rsa", "isn't valid", "signature"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			env := newCeremonyRouterEnv(t)
+			message := env.transportFor(t, tc.msgType, tc.message(env), env.version)
+
+			var signed *wire.SignedTransport
+			if tc.validInitSig {
+				signed = signAsInitiator(t, message)
+			} else {
+				valid := signAsInitiator(t, message)
+				signed = &wire.SignedTransport{
+					Message:   message,
+					Signer:    valid.Signer,
+					Signature: bytesRepeat(0x00, 256), // not a signature over this message
+				}
+			}
+
+			recorder := env.post(t, tc.route, signed)
+
+			require.Equal(t, http.StatusBadRequest, recorder.Code)
+			body, err := wire.ParseAsError(recorder.Body.Bytes())
+			require.NoError(t, err)
+			require.Equal(t, string(wire.InitiatorErrorCodeCeremonyFailed), body,
+				"a failed ceremony must present exactly the generic code and nothing else")
+			for _, leak := range tc.mustNotAppear {
+				require.NotContains(t, body, leak)
+			}
+		})
+	}
+}
+
+// TestCeremonyRoutesReportVersionMismatch asserts the one failure these routes do report
+// verbatim. Operators and initiator must run identical versions, so a mismatch is both the
+// most likely failure after an upgrade and one that says nothing about ceremony material —
+// reporting it as the generic code would leave operators with no way to diagnose it.
+func TestCeremonyRoutesReportVersionMismatch(t *testing.T) {
+	tests := []struct {
+		name    string
+		route   string
+		msgType wire.TransportType
+		message func(e *routerTestEnv) wire.SSZMarshaller
+	}{
+		{
+			name:    "resign",
+			route:   "/resign",
+			msgType: wire.SignedResignMessageType,
+			message: func(e *routerTestEnv) wire.SSZMarshaller { return e.resignBatchSignedByForeignKey(t) },
+		},
+		{
+			name:    "reshare",
+			route:   "/reshare",
+			msgType: wire.SignedReshareMessageType,
+			message: func(e *routerTestEnv) wire.SSZMarshaller { return e.reshareBatchStructurallyInvalid(t) },
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			env := newCeremonyRouterEnv(t)
+			message := env.transportFor(t, tc.msgType, tc.message(env), []byte("other.version"))
+			signed := signAsInitiator(t, message)
+
+			recorder := env.post(t, tc.route, signed)
+
+			require.Equal(t, http.StatusBadRequest, recorder.Code)
+			body, err := wire.ParseAsError(recorder.Body.Bytes())
+			require.NoError(t, err)
+			require.Equal(t, "wrong version: remote other.version local test.version", body,
+				"a version mismatch must name both versions so it can be acted on")
+			require.NotContains(t, body, string(wire.InitiatorErrorCodeCeremonyFailed))
+		})
+	}
 }
 
 // nonRSAPublicKey returns an encoded public key that parses as valid PEM but is not

--- a/pkgs/operator/state.go
+++ b/pkgs/operator/state.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/drand/kyber"
 	kyber_bls12381 "github.com/drand/kyber-bls12381"
 	kyber_dkg "github.com/drand/kyber/share/dkg"
@@ -46,7 +47,34 @@ type Switch struct {
 	EthClient        eip1271.ETHClient
 }
 
+// validateReshareStructure runs the reshare message checks that do not depend on this
+// operator's membership in the old operator set.
+func validateReshareStructure(reshare *spec.Reshare) error {
+	if !spec.UniqueAndOrderedOperators(reshare.OldOperators) {
+		return fmt.Errorf("old operators are not unique and ordered")
+	}
+	if !spec.UniqueAndOrderedOperators(reshare.NewOperators) {
+		return fmt.Errorf("new operators are not unique and ordered")
+	}
+	if !spec.ValidThresholdSet(reshare.OldT, reshare.OldOperators) {
+		return fmt.Errorf("old threshold set is invalid")
+	}
+	if !spec.ValidThresholdSet(reshare.NewT, reshare.NewOperators) {
+		return fmt.Errorf("new threshold set is invalid")
+	}
+	if !spec.ValidAmountSet(phase0.Gwei(reshare.Amount)) {
+		return fmt.Errorf("amount should be in range between 32 ETH and 2048 ETH")
+	}
+	if err := spec_crypto.ValidateWithdrawalCredentials(reshare.WithdrawalCredentials); err != nil {
+		return fmt.Errorf("invalid withdrawal credentials: %w", err)
+	}
+	return nil
+}
+
 func (s *Switch) getPublicCommitsAndSecretShare(reshareMsg *wire.ReshareMessage) ([]kyber.Point, *kyber_dkg.DistKeyShare, error) {
+	if err := validateReshareStructure(reshareMsg.Reshare); err != nil {
+		return nil, nil, err
+	}
 	// sanity check for incoming proofs len
 	if len(reshareMsg.Proofs) != len(reshareMsg.Reshare.OldOperators) {
 		return nil, nil, fmt.Errorf("wrong proofs len at reshare message: expected %d, got %d", len(reshareMsg.Reshare.OldOperators), len(reshareMsg.Proofs))

--- a/pkgs/operator/state_test.go
+++ b/pkgs/operator/state_test.go
@@ -317,8 +317,11 @@ func TestCrashByMaliciousOperatorAtReshare(t *testing.T) {
 			WithdrawalCredentials: spec_crypto.WithdrawalCredentials(spec_crypto.ETH1WithdrawalPrefix, [20]byte{}),
 			NewOperators:          ops[:4],
 			OldOperators:          ops[4:8],
+			OldT:                  3,
+			NewT:                  3,
 			Owner:                 common.HexToAddress("0xdcc846fa10c7cfce9e6eb37e06ed93b666cfc5e9"),
 			Nonce:                 1,
+			Amount:                uint64(spec_crypto.MIN_ACTIVATION_BALANCE),
 		},
 		Proofs: signedProofs[0],
 	}


### PR DESCRIPTION
Fixes two issues in the resign and reshare paths.

## 1. Ceremony proofs were validated against a caller-supplied key

`LocalOwner.Resign` selected the operator entry to validate the ceremony proof against from the operator list carried in the message, matching on ID. Since that list is supplied by the caller, the proof could be checked against a key the caller chose rather than this operator's own.

It now validates against this operator's own public key, and rejects the message if the operator is absent from the set.

## 2. Batch authorisation checked only the first message

For batched resign and reshare, the owner's EIP-1271 signature was verified against `Messages[0].Proofs[0].Proof.Owner`, after which every message in the batch was executed. A batch could therefore carry messages belonging to a different owner than the one that authorised it.

The authorised owner is now taken from the message being authorised, and every message in the batch is checked against it before any ceremony runs. Each message's own operator set is used rather than the first message's.

Ceremony failures are masked to a generic error, with a carve-out for version mismatch.
